### PR TITLE
Internal flush fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --features device
+          args: --verbose --features device,dirty-file-panic # always supply dirty-file-panic to find internal flushing issues
         if: ${{ matrix.run_tests }}
 
       - name: Run cargo build - no_std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ device = ["elain"]
 log = ["dep:log"]
 # enable defmt support
 defmt = ["dep:defmt"]
+# panic when dropping dirty files, files should be flushed before hand
+dirty-file-panic = []
 
 # Default features
 default = ["chrono", "std", "alloc", "lfn", "unicode", "log"]

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -6,16 +6,22 @@ use tokio::io::BufStream;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tokio::fs::copy("resources/fat32.img", "tmp/fat.img").await?;
     let img_file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open("fat.img")
+        .open("tmp/fat.img")
         .await
         .context("Failed to open image!")?;
     let buf_stream = BufStream::new(img_file);
     let options = FsOptions::new().update_accessed_date(true);
     let fs = FileSystem::new(buf_stream, options).await?;
+    // create a dir
+    fs.root_dir().create_dir("foo").await?;
+    // Write a file
     let mut file = fs.root_dir().create_file("hello.txt").await?;
     file.write_all(b"Hello World!").await?;
+    file.flush().await?;
+
     Ok(())
 }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -596,6 +596,9 @@ where
         // save new directory entry
         let sfn_entry = e.data.renamed(short_name);
         dst_dir.write_entry(dst_name, sfn_entry).await?;
+
+        // rename requires stream flush (no async drop :()
+        stream.flush().await?;
         Ok(())
     }
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -494,6 +494,8 @@ where
             stream.seek(SeekFrom::Current(-i64::from(DIR_ENTRY_SIZE))).await?;
             data.serialize(&mut stream).await?;
         }
+        // remove requires stream flush
+        stream.flush().await?;
         Ok(())
     }
 
@@ -703,6 +705,9 @@ where
         let start_abs_pos = end_abs_pos - u64::from(DIR_ENTRY_SIZE);
         // return new logical entry descriptor
         let short_name = ShortName::new(raw_entry.name());
+
+        // explicit flush call because async drop doesn't exist
+        stream.flush().await?;
         Ok(DirEntry {
             data: raw_entry,
             short_name,

--- a/src/file.rs
+++ b/src/file.rs
@@ -254,6 +254,9 @@ where
         if let Some(e) = &self.entry {
             if e.dirty() {
                 warn!("Dropping dirty file before flushing");
+                {
+                    panic!("Dropping unflushed file");
+                }
             }
         }
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -254,6 +254,7 @@ where
         if let Some(e) = &self.entry {
             if e.dirty() {
                 warn!("Dropping dirty file before flushing");
+                #[cfg(feature = "dirty-file-panic")]
                 {
                     panic!("Dropping unflushed file");
                 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -9,9 +9,9 @@ use core::u32;
 
 #[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
 use alloc::string::String;
-use embedded_io_async::WriteAllError;
 #[cfg(feature = "std")]
 use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_io_async::WriteAllError;
 
 use crate::boot_sector::{format_boot_sector, BiosParameterBlock, BootSector};
 use crate::dir::{Dir, DirRawStream};

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -23,63 +23,63 @@ async fn basic_fs_test(fs: &FileSystem) {
         assert_eq!(stats.total_clusters(), stats.free_clusters());
     }
 
-    // let root_dir = fs.root_dir();
-    // let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
-    // assert_eq!(entries.len(), 0);
+    let root_dir = fs.root_dir();
+    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    assert_eq!(entries.len(), 0);
 
-    // let subdir1 = root_dir.create_dir("subdir1").await.expect("create_dir subdir1");
-    // let subdir2 = root_dir
-    //     .create_dir("subdir1/subdir2 with long name")
-    //     .await
-    //     .expect("create_dir subdir2");
+    let subdir1 = root_dir.create_dir("subdir1").await.expect("create_dir subdir1");
+    let subdir2 = root_dir
+        .create_dir("subdir1/subdir2 with long name")
+        .await
+        .expect("create_dir subdir2");
 
-    // let test_str = TEST_STR.repeat(1000);
-    // {
-    //     let mut file = subdir2.create_file("test file name.txt").await.expect("create file");
-    //     file.truncate().await.expect("truncate file");
-    //     file.write_all(test_str.as_bytes()).await.expect("write file");
-    //     file.flush().await.unwrap(); // important, no more flush on drop :(
-    // }
+    let test_str = TEST_STR.repeat(1000);
+    {
+        let mut file = subdir2.create_file("test file name.txt").await.expect("create file");
+        file.truncate().await.expect("truncate file");
+        file.write_all(test_str.as_bytes()).await.expect("write file");
+        file.flush().await.unwrap(); // important, no more flush on drop :(
+    }
 
-    // let mut file = root_dir
-    //     .open_file("subdir1/subdir2 with long name/test file name.txt")
-    //     .await
-    //     .unwrap();
-    // let content = read_to_end(&mut file).await.unwrap();
-    // assert_eq!(core::str::from_utf8(&content).unwrap(), test_str);
+    let mut file = root_dir
+        .open_file("subdir1/subdir2 with long name/test file name.txt")
+        .await
+        .unwrap();
+    let content = read_to_end(&mut file).await.unwrap();
+    assert_eq!(core::str::from_utf8(&content).unwrap(), test_str);
 
-    // let filenames = root_dir
-    //     .iter()
-    //     .map(|r| async { r.unwrap().file_name() })
-    //     .collect::<Vec<String>>()
-    //     .await;
-    // assert_eq!(filenames, ["subdir1"]);
+    let filenames = root_dir
+        .iter()
+        .map(|r| async { r.unwrap().file_name() })
+        .collect::<Vec<String>>()
+        .await;
+    assert_eq!(filenames, ["subdir1"]);
 
-    // let filenames = subdir2
-    //     .iter()
-    //     .map(|r| async { r.unwrap().file_name() })
-    //     .collect::<Vec<String>>()
-    //     .await;
-    // assert_eq!(filenames, [".", "..", "test file name.txt"]);
+    let filenames = subdir2
+        .iter()
+        .map(|r| async { r.unwrap().file_name() })
+        .collect::<Vec<String>>()
+        .await;
+    assert_eq!(filenames, [".", "..", "test file name.txt"]);
 
-    // subdir1
-    //     .rename("subdir2 with long name/test file name.txt", &root_dir, "new-name.txt")
-    //     .await
-    //     .expect("rename");
+    subdir1
+        .rename("subdir2 with long name/test file name.txt", &root_dir, "new-name.txt")
+        .await
+        .expect("rename");
 
-    // let filenames = subdir2
-    //     .iter()
-    //     .map(|r| async { r.unwrap().file_name() })
-    //     .collect::<Vec<String>>()
-    //     .await;
-    // assert_eq!(filenames, [".", ".."]);
+    let filenames = subdir2
+        .iter()
+        .map(|r| async { r.unwrap().file_name() })
+        .collect::<Vec<String>>()
+        .await;
+    assert_eq!(filenames, [".", ".."]);
 
-    // let filenames = root_dir
-    //     .iter()
-    //     .map(|r| async { r.unwrap().file_name() })
-    //     .collect::<Vec<String>>()
-    //     .await;
-    // assert_eq!(filenames, ["subdir1", "new-name.txt"]);
+    let filenames = root_dir
+        .iter()
+        .map(|r| async { r.unwrap().file_name() })
+        .collect::<Vec<String>>()
+        .await;
+    assert_eq!(filenames, ["subdir1", "new-name.txt"]);
 }
 
 async fn test_format_fs(opts: embedded_fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSystem {

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -23,63 +23,63 @@ async fn basic_fs_test(fs: &FileSystem) {
         assert_eq!(stats.total_clusters(), stats.free_clusters());
     }
 
-    let root_dir = fs.root_dir();
-    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
-    assert_eq!(entries.len(), 0);
+    // let root_dir = fs.root_dir();
+    // let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    // assert_eq!(entries.len(), 0);
 
-    let subdir1 = root_dir.create_dir("subdir1").await.expect("create_dir subdir1");
-    let subdir2 = root_dir
-        .create_dir("subdir1/subdir2 with long name")
-        .await
-        .expect("create_dir subdir2");
+    // let subdir1 = root_dir.create_dir("subdir1").await.expect("create_dir subdir1");
+    // let subdir2 = root_dir
+    //     .create_dir("subdir1/subdir2 with long name")
+    //     .await
+    //     .expect("create_dir subdir2");
 
-    let test_str = TEST_STR.repeat(1000);
-    {
-        let mut file = subdir2.create_file("test file name.txt").await.expect("create file");
-        file.truncate().await.expect("truncate file");
-        file.write_all(test_str.as_bytes()).await.expect("write file");
-        file.flush().await.unwrap(); // important, no more flush on drop :(
-    }
+    // let test_str = TEST_STR.repeat(1000);
+    // {
+    //     let mut file = subdir2.create_file("test file name.txt").await.expect("create file");
+    //     file.truncate().await.expect("truncate file");
+    //     file.write_all(test_str.as_bytes()).await.expect("write file");
+    //     file.flush().await.unwrap(); // important, no more flush on drop :(
+    // }
 
-    let mut file = root_dir
-        .open_file("subdir1/subdir2 with long name/test file name.txt")
-        .await
-        .unwrap();
-    let content = read_to_end(&mut file).await.unwrap();
-    assert_eq!(core::str::from_utf8(&content).unwrap(), test_str);
+    // let mut file = root_dir
+    //     .open_file("subdir1/subdir2 with long name/test file name.txt")
+    //     .await
+    //     .unwrap();
+    // let content = read_to_end(&mut file).await.unwrap();
+    // assert_eq!(core::str::from_utf8(&content).unwrap(), test_str);
 
-    let filenames = root_dir
-        .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
-    assert_eq!(filenames, ["subdir1"]);
+    // let filenames = root_dir
+    //     .iter()
+    //     .map(|r| async { r.unwrap().file_name() })
+    //     .collect::<Vec<String>>()
+    //     .await;
+    // assert_eq!(filenames, ["subdir1"]);
 
-    let filenames = subdir2
-        .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
-    assert_eq!(filenames, [".", "..", "test file name.txt"]);
+    // let filenames = subdir2
+    //     .iter()
+    //     .map(|r| async { r.unwrap().file_name() })
+    //     .collect::<Vec<String>>()
+    //     .await;
+    // assert_eq!(filenames, [".", "..", "test file name.txt"]);
 
-    subdir1
-        .rename("subdir2 with long name/test file name.txt", &root_dir, "new-name.txt")
-        .await
-        .expect("rename");
+    // subdir1
+    //     .rename("subdir2 with long name/test file name.txt", &root_dir, "new-name.txt")
+    //     .await
+    //     .expect("rename");
 
-    let filenames = subdir2
-        .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
-    assert_eq!(filenames, [".", ".."]);
+    // let filenames = subdir2
+    //     .iter()
+    //     .map(|r| async { r.unwrap().file_name() })
+    //     .collect::<Vec<String>>()
+    //     .await;
+    // assert_eq!(filenames, [".", ".."]);
 
-    let filenames = root_dir
-        .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
-    assert_eq!(filenames, ["subdir1", "new-name.txt"]);
+    // let filenames = root_dir
+    //     .iter()
+    //     .map(|r| async { r.unwrap().file_name() })
+    //     .collect::<Vec<String>>()
+    //     .await;
+    // assert_eq!(filenames, ["subdir1", "new-name.txt"]);
 }
 
 async fn test_format_fs(opts: embedded_fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSystem {


### PR DESCRIPTION
Where the old `Drop` handler would catch these, we now have to manually flush in places where we modify directory entries.