### PR TITLE
Make `File::new_from_context` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@
     clippy::uninlined_format_args, // not supported before Rust 1.58.0
 )]
 #![feature(async_fn_in_trait)]
-#![feature(impl_trait_projections)]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;


### PR DESCRIPTION
For the best access latency, a `File` can now be created from an existing `FileContext` with _no_ verification. This contrasts the `DirEntry::try_to_file_with_context` which does some checking and ensures that only one "version" of the file can exist at one time.

- Should this method be marked as unsafe? I think not because there are other methods which could cause file corruption but are not unsafe.
- Perhaps this should return a "readonly" version of a file? A bunch more code for not a lot of gain I imagine. This API should be rarely used, only in the most latency-critical applications, or instances where the file system must yield to a higher priority task writing to a different file.