### PR TITLE
Remove async iterator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           command: build
 
+      - name: Run cargo build --examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --examples
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default = ["chrono", "std", "alloc", "lfn", "unicode", "log"]
 [dependencies]
 # core deps
 bitflags = "1.0"
-embedded-io-async = "0.6"
+embedded-io-async = "0.6.1"
 
 # optional deps
 embedded-io-adapters = { version = "0.6", package = "embedded-io-adapters", features = ["tokio-1"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ default = ["chrono", "std", "alloc", "lfn", "unicode", "log"]
 # core deps
 bitflags = "1.0"
 embedded-io-async = "0.6"
-async-iterator = { version = "2.1", default-features = false }
 
 # optional deps
 embedded-io-adapters = { version = "0.6", package = "embedded-io-adapters", features = ["tokio-1"], optional = true }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ embedded-fatfs
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
 [![crates.io](https://img.shields.io/crates/v/embedded-fatfs)](https://crates.io/crates/embedded-fatfs)
 [![Documentation](https://docs.rs/embedded-fatfs/badge.svg)](https://docs.rs/embedded-fatfs)
-![Minimum rustc version](https://img.shields.io/badge/rustc-nightly-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.75+-green.svg)
 
 A FAT filesystem library implemented in Rust. Built on the shoulders of the amazing [rust-fatfs](https://github.com/rafalh/rust-fatfs) crate by [@rafalh](https://github.com/rafalh).
 

--- a/examples/ls.rs
+++ b/examples/ls.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-use async_iterator::Iterator as AsyncIterator;
 use chrono::{DateTime, Local};
 use embedded_fatfs::{FileSystem, FsOptions};
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,7 +6,6 @@ use crate::error::Error;
 use crate::fs::{FileSystem, ReadWriteSeek};
 use crate::io::{IoBase, Read, Seek, SeekFrom, Write};
 use crate::time::{Date, DateTime, TimeProvider};
-use async_iterator::Iterator as AsyncIterator;
 
 const MAX_FILE_SIZE: u32 = core::u32::MAX;
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -71,9 +71,9 @@ impl<'a, IO: ReadWriteSeek, TP, OCC> File<'a, IO, TP, OCC> {
     /// **WARNING** This method has the power to corrupt the filesystem when misused.
     /// Read and write access is allowed simultaneously, however two or more write accesses will corrupt the file system.
     /// Avoid concurrent write access to ensure file system stability.
-    /// 
-    /// 
-    /// Prefer using [`DirEntry::try_to_file_with_context`](crate::dir_entry::DirEntry::try_to_file_with_context) where possible because 
+    ///
+    ///
+    /// Prefer using [`DirEntry::try_to_file_with_context`](crate::dir_entry::DirEntry::try_to_file_with_context) where possible because
     /// it does some basic checks to avoid file corruption.
     pub fn new_from_context(context: FileContext, fs: &'a FileSystem<IO, TP, OCC>) -> Self {
         File { context, fs }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 // Disable warnings to not clutter code with cfg too much
 #![cfg_attr(not(all(feature = "alloc", feature = "lfn")), allow(dead_code, unused_imports))]
 #![warn(clippy::pedantic)]
+// #![warn(missing_docs)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::cast_possible_truncation,

--- a/src/table.rs
+++ b/src/table.rs
@@ -637,7 +637,6 @@ where
         Ok(num_free)
     }
 
-    
     pub async fn next(&mut self) -> Option<Result<u32, Error<E>>> {
         if self.err {
             return None;

--- a/src/table.rs
+++ b/src/table.rs
@@ -5,7 +5,6 @@ use core::marker::PhantomData;
 use crate::error::{Error, IoError, ReadExactError};
 use crate::fs::{FatType, FsStatusFlags};
 use crate::io::{self, IoBase, Read, ReadLeExt, Seek, Write, WriteLeExt};
-use async_iterator::Iterator as AsyncIterator;
 
 struct Fat<S> {
     phantom: PhantomData<S>,
@@ -637,18 +636,9 @@ where
         }
         Ok(num_free)
     }
-}
 
-impl<B, E, S> AsyncIterator for ClusterIterator<B, E, S>
-where
-    B: BorrowMut<S>,
-    E: IoError,
-    S: Read + Write + Seek,
-    Error<E>: From<S::Error> + From<ReadExactError<S::Error>>,
-{
-    type Item = Result<u32, Error<E>>;
-
-    async fn next(&mut self) -> Option<Self::Item> {
+    
+    pub async fn next(&mut self) -> Option<Result<u32, Error<E>>> {
         if self.err {
             return None;
         }
@@ -717,8 +707,15 @@ mod tests {
         assert_eq!(count_free_clusters(&mut cur, fat_type, 0x1E).await.ok(), Some(3));
         // test reading from iterator
         {
-            let iter = ClusterIterator::<&mut S, S::Error, S>::new(&mut cur, fat_type, 0x9);
-            let actual_cluster_numbers = iter.map(|s| async { s.ok() }).collect::<Vec<_>>().await;
+            let mut iter = ClusterIterator::<&mut S, S::Error, S>::new(&mut cur, fat_type, 0x9);
+            let actual_cluster_numbers = {
+                let mut v = Vec::new();
+                while let Some(i) = iter.next().await {
+                    v.push(i.ok())
+                }
+
+                v
+            };
             let expected_cluster_numbers = [0xA_u32, 0x14_u32, 0x15_u32, 0x16_u32, 0x19_u32, 0x1A_u32]
                 .iter()
                 .cloned()

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use async_iterator::Iterator as AsyncIterator;
 use embedded_fatfs::{ChronoTimeProvider, LossyOemCpConverter};
 use embedded_io_async::Write;
 
@@ -24,7 +23,8 @@ async fn basic_fs_test(fs: &FileSystem) {
     }
 
     let root_dir = fs.root_dir();
-    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    let entries = root_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     assert_eq!(entries.len(), 0);
 
     let subdir1 = root_dir.create_dir("subdir1").await.expect("create_dir subdir1");
@@ -50,16 +50,20 @@ async fn basic_fs_test(fs: &FileSystem) {
 
     let filenames = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(filenames, ["subdir1"]);
 
     let filenames = subdir2
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(filenames, [".", "..", "test file name.txt"]);
 
     subdir1
@@ -69,16 +73,20 @@ async fn basic_fs_test(fs: &FileSystem) {
 
     let filenames = subdir2
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(filenames, [".", ".."]);
 
     let filenames = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(filenames, ["subdir1", "new-name.txt"]);
 }
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,6 +1,5 @@
 use std::str;
 
-use async_iterator::Iterator;
 use embedded_fatfs::{ChronoTimeProvider, FatType, FsOptions, LossyOemCpConverter};
 use embedded_io_async::{Read, Seek, SeekFrom};
 
@@ -23,7 +22,8 @@ async fn create_fs(name: &str) -> FileSystem {
 
 async fn test_root_dir(fs: FileSystem) {
     let root_dir = fs.root_dir();
-    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    let entries = root_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     let short_names = entries.iter().map(|e| e.short_file_name()).collect::<Vec<String>>();
     assert_eq!(short_names, ["LONG.TXT", "SHORT.TXT", "VERY", "VERY-L~1"]);
     let names = entries.iter().map(|e| e.file_name()).collect::<Vec<String>>();
@@ -31,9 +31,11 @@ async fn test_root_dir(fs: FileSystem) {
     // Try read again
     let names2 = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names2, names);
 }
 
@@ -154,30 +156,38 @@ async fn test_get_dir_by_path(fs: FileSystem) {
     let dir = root_dir.open_dir("very/long/path/").await.unwrap();
     let names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt"]);
 
     let dir2 = root_dir.open_dir("very/long/path/././.").await.unwrap();
     let names2 = dir2
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names2, [".", "..", "test.txt"]);
 
     let root_dir2 = root_dir.open_dir("very/long/path/../../..").await.unwrap();
     let root_names = root_dir2
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     let root_names2 = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(root_names, root_names2);
 
     root_dir.open_dir("VERY-L~1").await.unwrap();

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 use std::str;
 use tokio::fs;
 
-use async_iterator::Iterator as AsyncIterator;
 use embedded_fatfs::{ChronoTimeProvider, FsOptions, LossyOemCpConverter};
 use embedded_io_async::{Seek, SeekFrom, Write};
 
@@ -112,31 +111,39 @@ async fn test_remove(fs: FileSystem) {
     let dir = root_dir.open_dir("very/long/path").await.unwrap();
     let mut names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt"]);
     root_dir.remove("very/long/path/test.txt").await.unwrap();
     names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", ".."]);
     assert!(root_dir.remove("very/long/path").await.is_ok());
 
     names = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, ["long.txt", "short.txt", "very", "very-long-dir-name"]);
     root_dir.remove("long.txt").await.unwrap();
     names = root_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, ["short.txt", "very", "very-long-dir-name"]);
 }
 
@@ -160,9 +167,11 @@ async fn test_create_file(fs: FileSystem) {
     let dir = root_dir.open_dir("very/long/path").await.unwrap();
     let mut names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt"]);
     {
         // test some invalid names
@@ -178,15 +187,19 @@ async fn test_create_file(fs: FileSystem) {
     // check for dir entry
     names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt", "new-file-with-long-name.txt"]);
     names = dir
         .iter()
-        .map(|r| async { r.unwrap().short_file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().short_file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "TEST.TXT", "NEW-FI~1.TXT"]);
     {
         // check contents
@@ -204,9 +217,11 @@ async fn test_create_file(fs: FileSystem) {
     }
     names = dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names.len(), 4 + 512 / 32);
     // check creating existing file opens it
     {
@@ -241,9 +256,11 @@ async fn test_create_dir(fs: FileSystem) {
     let parent_dir = root_dir.open_dir("very/long/path").await.unwrap();
     let mut names = parent_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt"]);
     {
         let subdir = root_dir
@@ -252,17 +269,21 @@ async fn test_create_dir(fs: FileSystem) {
             .unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", ".."]);
     }
     // check if new entry is visible in parent
     names = parent_dir
         .iter()
-        .map(|r| async { r.unwrap().file_name() })
-        .collect::<Vec<String>>()
-        .await;
+        .collect()
+        .await
+        .iter()
+        .map(|r| r.as_ref().unwrap().file_name())
+        .collect::<Vec<String>>();
     assert_eq!(names, [".", "..", "test.txt", "new-dir-with-long-name"]);
     {
         // Check if new directory can be opened and read
@@ -272,9 +293,11 @@ async fn test_create_dir(fs: FileSystem) {
             .unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", ".."]);
     }
     // Check if '.' is alias for new directory
@@ -285,9 +308,11 @@ async fn test_create_dir(fs: FileSystem) {
             .unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", ".."]);
     }
     // Check if '..' is alias for parent directory
@@ -298,9 +323,11 @@ async fn test_create_dir(fs: FileSystem) {
             .unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", "..", "test.txt", "new-dir-with-long-name"]);
     }
     // check if creating existing directory returns it
@@ -308,9 +335,11 @@ async fn test_create_dir(fs: FileSystem) {
         let subdir = root_dir.create_dir("very").await.unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", "..", "long"]);
     }
     // check short names validity after create_dir
@@ -318,9 +347,11 @@ async fn test_create_dir(fs: FileSystem) {
         let subdir = root_dir.create_dir("test").await.unwrap();
         names = subdir
             .iter()
-            .map(|r| async { r.unwrap().short_file_name() })
-            .collect::<Vec<String>>()
-            .await;
+            .collect()
+            .await
+            .iter()
+            .map(|r| r.as_ref().unwrap().short_file_name())
+            .collect::<Vec<String>>();
         assert_eq!(names, [".", ".."]);
     }
 
@@ -346,11 +377,8 @@ async fn test_create_dir_fat32() {
 async fn test_rename_file(fs: FileSystem) {
     let root_dir = fs.root_dir();
     let parent_dir = root_dir.open_dir("very/long/path").await.unwrap();
-    let entries = parent_dir
-        .iter()
-        .map(|r| async { r.unwrap() })
-        .collect::<Vec<_>>()
-        .await;
+    let entries = parent_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
     assert_eq!(names, [".", "..", "test.txt"]);
     assert_eq!(entries[2].len(), 14);
@@ -360,11 +388,8 @@ async fn test_rename_file(fs: FileSystem) {
         .rename("test.txt", &parent_dir, "new-long-name.txt")
         .await
         .unwrap();
-    let entries = parent_dir
-        .iter()
-        .map(|r| async { r.unwrap() })
-        .collect::<Vec<_>>()
-        .await;
+    let entries = parent_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
     assert_eq!(names, [".", "..", "new-long-name.txt"]);
     assert_eq!(entries[2].len(), TEST_STR2.len() as u64);
@@ -376,7 +401,8 @@ async fn test_rename_file(fs: FileSystem) {
         .rename("new-long-name.txt", &root_dir, "moved-file.txt")
         .await
         .unwrap();
-    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    let entries = root_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
     assert_eq!(
         names,
@@ -388,7 +414,8 @@ async fn test_rename_file(fs: FileSystem) {
     assert_eq!(str::from_utf8(&buf).unwrap(), TEST_STR2);
 
     assert!(root_dir.rename("moved-file.txt", &root_dir, "short.txt").await.is_err());
-    let entries = root_dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+    let entries = root_dir.iter().collect().await;
+    let entries = entries.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
     let names = entries.iter().map(|r| r.file_name()).collect::<Vec<_>>();
     assert_eq!(
         names,
@@ -463,7 +490,8 @@ async fn test_multiple_files_in_directory(fs: FileSystem) {
         file.write_all(TEST_STR.as_bytes()).await.unwrap();
         file.flush().await.unwrap();
 
-        let files = dir.iter().map(|r| async { r.unwrap() }).collect::<Vec<_>>().await;
+        let files = dir.iter().collect().await;
+        let files = files.iter().map(|r| r.as_ref().unwrap()).collect::<Vec<_>>();
         let file = files.iter().find(|e| e.file_name() == name).unwrap();
         assert_eq!(TEST_STR.len() as u64, file.len(), "Wrong file len on iteration {}", i);
     }


### PR DESCRIPTION
It's not actively maintained, and only offered a few combinators. It also currently doesn't compile on stable. It's easier to just not use combinators until we have a stable solution for async iteration.