### PR TITLE
Aligned blocks at the `BlockDevice` level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@
 resolver = "2"
 members = ["block-device-driver", "block-device-adapters",  "embedded-fatfs", "sdspi"]
 exclude = ["examples/esp32c6"]
+
+[patch.crates-io]
+aligned = { git = "https://github.com/MabezDev/aligned", branch = "a1" }

--- a/block-device-adapters/Cargo.toml
+++ b/block-device-adapters/Cargo.toml
@@ -12,7 +12,7 @@ Block device adapters for managing byte level access and partitions
 """
 
 [dependencies]
-elain = { version = "0.3" }
+aligned = "0.4.1"
 embedded-io-async = "0.6.1"
 block-device-driver = { version = "0.1", path = "../block-device-driver" }
 

--- a/block-device-adapters/src/buf_stream.rs
+++ b/block-device-adapters/src/buf_stream.rs
@@ -1,5 +1,5 @@
 use aligned::Aligned;
-use block_device_driver::BlockDevice;
+use block_device_driver::{slice_to_blocks, slice_to_blocks_mut, BlockDevice};
 use embedded_io_async::{ErrorKind, Read, Seek, SeekFrom, Write};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -220,36 +220,6 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> Write for BufStream<T, SIZE> {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         self.flush().await?;
         Ok(())
-    }
-}
-
-fn slice_to_blocks<ALIGN, const SIZE: usize>(slice: &[u8]) -> &[Aligned<ALIGN, [u8; SIZE]>]
-where
-    ALIGN: aligned::Alignment,
-{
-    assert!(slice.len() % SIZE == 0);
-    // Note unsafe: we check the buf has the correct SIZE before casting
-    unsafe {
-        core::slice::from_raw_parts(
-            slice.as_ptr() as *const Aligned<ALIGN, [u8; SIZE]>,
-            slice.len() / SIZE,
-        )
-    }
-}
-
-fn slice_to_blocks_mut<ALIGN, const SIZE: usize>(
-    slice: &mut [u8],
-) -> &mut [Aligned<ALIGN, [u8; SIZE]>]
-where
-    ALIGN: aligned::Alignment,
-{
-    assert!(slice.len() % SIZE == 0);
-    // Note unsafe: we check the buf has the correct SIZE before casting
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            slice.as_mut_ptr() as *mut Aligned<ALIGN, [u8; SIZE]>,
-            slice.len() / SIZE,
-        )
     }
 }
 

--- a/block-device-driver/Cargo.toml
+++ b/block-device-driver/Cargo.toml
@@ -12,3 +12,4 @@ Block device trait
 """
 
 [dependencies]
+elain = { version = "0.3" }

--- a/block-device-driver/Cargo.toml
+++ b/block-device-driver/Cargo.toml
@@ -12,4 +12,4 @@ Block device trait
 """
 
 [dependencies]
-elain = { version = "0.3" }
+aligned = "0.4.1"

--- a/block-device-driver/src/lib.rs
+++ b/block-device-driver/src/lib.rs
@@ -10,13 +10,17 @@ use aligned::Aligned;
 ///
 /// [`BlockDevice<const SIZE: usize>`](BlockDevice) can be initialized with the following parameters.
 ///
-/// - `SIZE`: The size of the block in the block device.
+/// - `const SIZE`: The size of the block in the block device.
+/// - `type Align`: The [`aligned::Alignment`] of the block buffers for this implementation.
+/// - `type Error`: The error type for the implementation.
 ///
 /// The generic parameter `SIZE` on [BlockDevice] is the number of _bytes_ in a block
 /// for this block device.
 ///
 /// All addresses are zero indexed, and the unit is blocks. For example to read bytes
 /// from 1024 to 1536, the supplied block address would be 2.
+///
+/// <div class="warning">Alignment of the buffer <b>must</b> be multiple of SIZE.</div>
 ///
 /// This trait can be implemented multiple times to support various different block sizes.
 pub trait BlockDevice<const SIZE: usize> {
@@ -66,5 +70,108 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> BlockDevice<SIZE> for &mut T {
 
     async fn size(&mut self) -> Result<u64, Self::Error> {
         (*self).size().await
+    }
+}
+
+/// Cast a byte slice to an aligned slice of blocks.
+///
+/// This function panics if
+///
+/// * ALIGNment is not a multiple of SIZE
+/// * The input slice is not a multiple of SIZE
+/// * The input slice does not have the correct alignment.
+pub fn slice_to_blocks<ALIGN, const SIZE: usize>(slice: &[u8]) -> &[Aligned<ALIGN, [u8; SIZE]>]
+where
+    ALIGN: aligned::Alignment,
+{
+    let align: usize = core::mem::align_of::<Aligned<ALIGN, ()>>();
+    assert!(slice.len() % SIZE == 0);
+    assert!(slice.len() % align == 0);
+    assert!(slice.as_ptr().cast::<u8>() as usize % align == 0);
+    // Note unsafe: we check the buf has the correct SIZE and ALIGNment before casting
+    unsafe {
+        core::slice::from_raw_parts(
+            slice.as_ptr() as *const Aligned<ALIGN, [u8; SIZE]>,
+            slice.len() / SIZE,
+        )
+    }
+}
+
+/// Cast a mutable byte slice to an aligned mutable slice of blocks.
+///
+/// This function panics if
+///
+/// * ALIGNment is not a multiple of SIZE
+/// * The input slice is not a multiple of SIZE
+/// * The input slice does not have the correct alignment.
+pub fn slice_to_blocks_mut<ALIGN, const SIZE: usize>(
+    slice: &mut [u8],
+) -> &mut [Aligned<ALIGN, [u8; SIZE]>]
+where
+    ALIGN: aligned::Alignment,
+{
+    let align: usize = core::mem::align_of::<Aligned<ALIGN, [u8; SIZE]>>();
+    assert!(slice.len() % SIZE == 0);
+    assert!(slice.len() % align == 0);
+    assert!(slice.as_ptr().cast::<u8>() as usize % align == 0);
+    // Note unsafe: we check the buf has the correct SIZE and ALIGNment before casting
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            slice.as_mut_ptr() as *mut Aligned<ALIGN, [u8; SIZE]>,
+            slice.len() / SIZE,
+        )
+    }
+}
+
+/// Cast a slice of aligned blocks to a byte slice
+///
+/// This function panics if
+///
+/// * ALIGNment is not a multiple of SIZE
+pub fn blocks_to_slice<ALIGN, const SIZE: usize>(buf: &[Aligned<ALIGN, [u8; SIZE]>]) -> &[u8]
+where
+    ALIGN: aligned::Alignment,
+{
+    // We only need to assert that ALIGN is a multiple of SIZE, the other invariants are checked via the type system.
+    // This relationship must be true to avoid padding bytes which will introduce UB when casting.
+    let align: usize = core::mem::align_of::<Aligned<ALIGN, ()>>();
+    assert!(SIZE % align == 0);
+    // Note unsafe: we check the buf has the correct SIZE and ALIGNment before casting
+    unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * SIZE) }
+}
+
+/// Cast a mutable slice of aligned blocks to a mutable byte slice
+///
+/// This function panics if
+///
+/// * ALIGNment is not a multiple of SIZE
+pub fn blocks_to_slice_mut<ALIGN, const SIZE: usize>(
+    buf: &mut [Aligned<ALIGN, [u8; SIZE]>],
+) -> &mut [u8]
+where
+    ALIGN: aligned::Alignment,
+{
+    // We only need to assert that ALIGN is a multiple of SIZE, the other invariants are checked via the type system.
+    // This relationship must be true to avoid padding bytes which will introduce UB when casting.
+    let align: usize = core::mem::align_of::<Aligned<ALIGN, ()>>();
+    assert!(SIZE % align == 0);
+    // Note unsafe: we check the buf has the correct SIZE and ALIGNment before casting
+    unsafe { core::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, buf.len() * SIZE) }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_conversion_round_trip() {
+        let blocks = &mut [
+            Aligned::<aligned::A4, _>([0; 512]),
+            Aligned::<aligned::A4, _>([0; 512]),
+        ];
+        let slice = blocks_to_slice_mut(blocks);
+        assert!(slice.len() == 1024);
+        let blocks: &mut [Aligned<aligned::A4, [u8; 512]>] = slice_to_blocks_mut(slice);
+        assert!(blocks.len() == 2);
     }
 }

--- a/block-device-driver/src/lib.rs
+++ b/block-device-driver/src/lib.rs
@@ -4,59 +4,54 @@
 #![warn(missing_docs)]
 #![allow(async_fn_in_trait)]
 
-use elain::{Align, Alignment};
+use aligned::Aligned;
 
 /// A trait for a block devices
 ///
-/// [`BlockDevice<const SIZE: usize, const ALIGN: usize>`](BlockDevice) can be initialized with the following parameters.
+/// [`BlockDevice<const SIZE: usize>`](BlockDevice) can be initialized with the following parameters.
 ///
-/// - `SIZE`: The size of the block, this dictates the size of the internal buffer.
-/// - `ALIGN`: The alignment of the block buffers, this defaults to 1 unless
-///            specified in the trait impl. Alignment must be a power of two.
+/// - `SIZE`: The size of the block in the block device.
 ///
-/// The generic parameter `SIZE` on [BlockDevice] is the number of _bytes_ in a block 
+/// The generic parameter `SIZE` on [BlockDevice] is the number of _bytes_ in a block
 /// for this block device.
 ///
 /// All addresses are zero indexed, and the unit is blocks. For example to read bytes
 /// from 1024 to 1536, the supplied block address would be 2.
 ///
 /// This trait can be implemented multiple times to support various different block sizes.
-pub trait BlockDevice<const SIZE: usize, const ALIGN: usize = 1>
-where
-    Align<ALIGN>: Alignment,
-{
+pub trait BlockDevice<const SIZE: usize> {
     /// The error type for the BlockDevice implementation.
     type Error: core::fmt::Debug;
+
+    /// The alignment requirements of the block buffers.
+    type Align: aligned::Alignment;
 
     /// Read one or more blocks at the given block address.
     async fn read(
         &mut self,
         block_address: u32,
-        data: &mut [AlignedBuffer<SIZE, ALIGN>],
+        data: &mut [Aligned<Self::Align, [u8; SIZE]>],
     ) -> Result<(), Self::Error>;
 
     /// Write one or more blocks at the given block address.
     async fn write(
         &mut self,
         block_address: u32,
-        data: &[AlignedBuffer<SIZE, ALIGN>],
+        data: &[Aligned<Self::Align, [u8; SIZE]>],
     ) -> Result<(), Self::Error>;
 
     /// Report the size of the block device in bytes.
     async fn size(&mut self) -> Result<u64, Self::Error>;
 }
 
-impl<T: BlockDevice<SIZE, ALIGN>, const SIZE: usize, const ALIGN: usize> BlockDevice<SIZE, ALIGN>
-    for &mut T
-where
-    Align<ALIGN>: Alignment,
-{
+impl<T: BlockDevice<SIZE>, const SIZE: usize> BlockDevice<SIZE> for &mut T {
     type Error = T::Error;
+    type Align = T::Align;
 
     async fn read(
         &mut self,
         block_address: u32,
-        data: &mut [AlignedBuffer<SIZE, ALIGN>],
+        data: &mut [Aligned<Self::Align, [u8; SIZE]>],
     ) -> Result<(), Self::Error> {
         (*self).read(block_address, data).await
     }
@@ -64,71 +59,12 @@ where
     async fn write(
         &mut self,
         block_address: u32,
-        data: &[AlignedBuffer<SIZE, ALIGN>],
+        data: &[Aligned<Self::Align, [u8; SIZE]>],
     ) -> Result<(), Self::Error> {
         (*self).write(block_address, data).await
     }
 
     async fn size(&mut self) -> Result<u64, Self::Error> {
         (*self).size().await
-    }
-}
-
-/// AlignedBuffer
-///
-/// A representation of an buffer with specific length and alignment requirements.
-#[derive(Clone)]
-#[repr(C)]
-pub struct AlignedBuffer<const SIZE: usize, const ALIGN: usize>
-where
-    Align<ALIGN>: Alignment,
-{
-    _align: Align<ALIGN>,
-    buffer: [u8; SIZE],
-}
-
-impl<const SIZE: usize, const ALIGN: usize> AlignedBuffer<SIZE, ALIGN>
-where
-    Align<ALIGN>: Alignment,
-{
-    /// Creates a new AlignedBuffer.
-    pub const fn new() -> Self {
-        Self {
-            _align: Align::NEW,
-            buffer: [0; SIZE],
-        }
-    }
-}
-
-impl<const SIZE: usize, const ALIGN: usize> core::ops::Deref for AlignedBuffer<SIZE, ALIGN>
-where
-    Align<ALIGN>: Alignment,
-{
-    type Target = [u8; SIZE];
-
-    fn deref(&self) -> &Self::Target {
-        &self.buffer
-    }
-}
-
-impl<const SIZE: usize, const ALIGN: usize> core::ops::DerefMut for AlignedBuffer<SIZE, ALIGN>
-where
-    Align<ALIGN>: Alignment,
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.buffer
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn basic() {
-        assert!(core::mem::size_of::<AlignedBuffer<512, 4>>() == 512);
-
-        let buf: AlignedBuffer<512, 4> = AlignedBuffer::new();
-        assert!(buf.as_ptr().cast::<u8>() as usize % 4 == 0);
     }
 }

--- a/block-device-driver/src/lib.rs
+++ b/block-device-driver/src/lib.rs
@@ -1,42 +1,128 @@
-#![no_std]
+//! An abstraction of block devices.
+
+#![cfg_attr(not(test), no_std)]
+#![warn(missing_docs)]
 #![allow(async_fn_in_trait)]
+
+use elain::{Align, Alignment};
 
 /// A trait for a block devices
 ///
+/// [`BlockDevice<const SIZE: usize, const ALIGN: usize>`](BlockDevice) can be initialized with the following parameters.
+///
+/// - `SIZE`: The size of the block, this dictates the size of the internal buffer.
+/// - `ALIGN`: The alignment of the block buffers, this defaults to 1 unless
+///            specified in the trait impl. Alignment must be a power of two.
+///
 /// This trait can be implemented multiple times to support various different block sizes.
-pub trait BlockDevice<const SIZE: usize> {
+pub trait BlockDevice<const SIZE: usize, const ALIGN: usize = 1>
+where
+    Align<ALIGN>: Alignment,
+{
+    /// The error type for the BlockDevice implementation.
     type Error: core::fmt::Debug;
 
     /// Read one or more blocks at the given block address.
     async fn read(
         &mut self,
         block_address: u32,
-        data: &mut [[u8; SIZE]],
+        data: &mut [AlignedBuffer<SIZE, ALIGN>],
     ) -> Result<(), Self::Error>;
 
     /// Write one or more blocks at the given block address.
-    async fn write(&mut self, block_address: u32, data: &[[u8; SIZE]]) -> Result<(), Self::Error>;
+    async fn write(
+        &mut self,
+        block_address: u32,
+        data: &[AlignedBuffer<SIZE, ALIGN>],
+    ) -> Result<(), Self::Error>;
 
-    // Report the size of the block device.
+    /// Report the size of the block device.
     async fn size(&mut self) -> Result<u64, Self::Error>;
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> BlockDevice<SIZE> for &mut T {
+impl<T: BlockDevice<SIZE, ALIGN>, const SIZE: usize, const ALIGN: usize> BlockDevice<SIZE, ALIGN>
+    for &mut T
+where
+    Align<ALIGN>: Alignment,
+{
     type Error = T::Error;
 
     async fn read(
         &mut self,
         block_address: u32,
-        data: &mut [[u8; SIZE]],
+        data: &mut [AlignedBuffer<SIZE, ALIGN>],
     ) -> Result<(), Self::Error> {
         (*self).read(block_address, data).await
     }
 
-    async fn write(&mut self, block_address: u32, data: &[[u8; SIZE]]) -> Result<(), Self::Error> {
+    async fn write(
+        &mut self,
+        block_address: u32,
+        data: &[AlignedBuffer<SIZE, ALIGN>],
+    ) -> Result<(), Self::Error> {
         (*self).write(block_address, data).await
     }
 
     async fn size(&mut self) -> Result<u64, Self::Error> {
         (*self).size().await
+    }
+}
+
+/// AlignedBuffer
+///
+/// A representation of an buffer with specific length and alignment requirements.
+#[derive(Clone)]
+#[repr(C)]
+pub struct AlignedBuffer<const SIZE: usize, const ALIGN: usize>
+where
+    Align<ALIGN>: Alignment,
+{
+    _align: Align<ALIGN>,
+    buffer: [u8; SIZE],
+}
+
+impl<const SIZE: usize, const ALIGN: usize> AlignedBuffer<SIZE, ALIGN>
+where
+    Align<ALIGN>: Alignment,
+{
+    /// Creates a new AlignedBuffer.
+    pub const fn new() -> Self {
+        Self {
+            _align: Align::NEW,
+            buffer: [0; SIZE],
+        }
+    }
+}
+
+impl<const SIZE: usize, const ALIGN: usize> core::ops::Deref for AlignedBuffer<SIZE, ALIGN>
+where
+    Align<ALIGN>: Alignment,
+{
+    type Target = [u8; SIZE];
+
+    fn deref(&self) -> &Self::Target {
+        &self.buffer
+    }
+}
+
+impl<const SIZE: usize, const ALIGN: usize> core::ops::DerefMut for AlignedBuffer<SIZE, ALIGN>
+where
+    Align<ALIGN>: Alignment,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.buffer
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        assert!(core::mem::size_of::<AlignedBuffer<512, 4>>() == 512);
+
+        let buf: AlignedBuffer<512, 4> = AlignedBuffer::new();
+        assert!(buf.as_ptr().cast::<u8>() as usize % 4 == 0);
     }
 }

--- a/block-device-driver/src/lib.rs
+++ b/block-device-driver/src/lib.rs
@@ -14,6 +14,12 @@ use elain::{Align, Alignment};
 /// - `ALIGN`: The alignment of the block buffers, this defaults to 1 unless
 ///            specified in the trait impl. Alignment must be a power of two.
 ///
+/// The generic parameter `SIZE` on [BlockDevice] is the number of _bytes_ in a block 
+/// for this block device.
+///
+/// All addresses are zero indexed, and the unit is blocks. For example to read bytes
+/// from 1024 to 1536, the supplied block address would be 2.
+///
 /// This trait can be implemented multiple times to support various different block sizes.
 pub trait BlockDevice<const SIZE: usize, const ALIGN: usize = 1>
 where
@@ -36,7 +42,7 @@ where
         data: &[AlignedBuffer<SIZE, ALIGN>],
     ) -> Result<(), Self::Error>;
 
-    /// Report the size of the block device.
+    /// Report the size of the block device in bytes.
     async fn size(&mut self) -> Result<u64, Self::Error>;
 }
 

--- a/examples/esp32c6/Cargo.toml
+++ b/examples/esp32c6/Cargo.toml
@@ -17,6 +17,7 @@ static_cell = { version = "1", features = ["nightly"] }
 embedded-io-async = "0.6"
 
 sdspi = { version = "0.1.0", path = "../../sdspi", features = ["log"] }
+aligned = "0.4.1"
 block-device-adapters = { version = "0.1.0", path = "../../block-device-adapters" }
 embedded-fatfs = { version = "0.1.0", path = "../../embedded-fatfs", default-features = false, features = ["log"] }
 
@@ -24,3 +25,4 @@ embedded-fatfs = { version = "0.1.0", path = "../../embedded-fatfs", default-fea
 [patch.crates-io]
 esp32c6-hal = { git = "https://github.com/MabezDev/esp-hal/", branch = "async-stable" }
 esp-hal = { git = "https://github.com/MabezDev/esp-hal/", branch = "async-stable" }
+aligned = { git = "https://github.com/MabezDev/aligned", branch = "a1" }

--- a/examples/esp32c6/src/main.rs
+++ b/examples/esp32c6/src/main.rs
@@ -59,7 +59,11 @@ async fn main(_spawner: Spawner) {
 
     let spi = FlashSafeDma::<_, 512>::new(spi);
 
-    let mut sd = sdspi::SdSpi::new(spi, cs.into_push_pull_output(), Delay(embassy_time::Delay));
+    let mut sd = sdspi::SdSpi::<_, _, _, aligned::A1>::new(
+        spi,
+        cs.into_push_pull_output(),
+        Delay(embassy_time::Delay),
+    );
 
     // Initialize the card
     sd.init().await.unwrap();
@@ -71,7 +75,7 @@ async fn main(_spawner: Spawner) {
 
     log::info!("Initialization complete!");
 
-    let inner = BufStream::<_, 512, 4>::new(sd);
+    let inner = BufStream::<_, 512>::new(sd);
 
     let fs = embedded_fatfs::FileSystem::new(inner, FsOptions::new())
         .await

--- a/sdspi/Cargo.toml
+++ b/sdspi/Cargo.toml
@@ -9,7 +9,7 @@ embedded-hal = "1"
 sdio-host = "0.9.0"
 block-device-driver = { version = "0.1.0", path = "../block-device-driver" }
 embassy-futures = "0.1.1"
-elain = { version = "0.3" }
+aligned = "0.4.1"
 
 log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }

--- a/sdspi/Cargo.toml
+++ b/sdspi/Cargo.toml
@@ -9,6 +9,7 @@ embedded-hal = "1"
 sdio-host = "0.9.0"
 block-device-driver = { version = "0.1.0", path = "../block-device-driver" }
 embassy-futures = "0.1.1"
+elain = { version = "0.3" }
 
 log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }

--- a/sdspi/src/lib.rs
+++ b/sdspi/src/lib.rs
@@ -2,14 +2,13 @@
 
 #![no_std]
 
-use block_device_driver::AlignedBuffer;
+use aligned::Aligned;
 use core::fmt::Debug;
 use core::future::Future;
+use core::marker::PhantomData;
 use embassy_futures::select::{select, Either};
 use sdio_host::sd::{CardCapacity, CID, CSD, OCR, SD};
 use sdio_host::{common_cmd::*, sd_cmd::*};
-
-use elain::{Align, Alignment};
 
 // MUST be the first module listed
 mod fmt;
@@ -70,23 +69,26 @@ pub enum Error {
     WriteError,
 }
 
-pub struct SdSpi<SPI, CS, D>
+pub struct SdSpi<SPI, CS, D, ALIGN>
 where
     SPI: embedded_hal_async::spi::SpiBus,
     CS: embedded_hal::digital::OutputPin,
     D: embedded_hal_async::delay::DelayNs,
+    ALIGN: aligned::Alignment,
 {
     spi: SPI,
     cs: CS,
     delay: D,
     card: Option<Card>,
+    _align: PhantomData<ALIGN>,
 }
 
-impl<SPI, CS, D> SdSpi<SPI, CS, D>
+impl<SPI, CS, D, ALIGN> SdSpi<SPI, CS, D, ALIGN>
 where
     SPI: embedded_hal_async::spi::SpiBus,
     CS: embedded_hal::digital::OutputPin,
     D: embedded_hal_async::delay::DelayNs + Clone,
+    ALIGN: aligned::Alignment,
 {
     pub fn new(spi: SPI, cs: CS, delay: D) -> Self {
         Self {
@@ -94,6 +96,7 @@ where
             cs,
             delay,
             card: None,
+            _align: PhantomData,
         }
     }
 
@@ -209,14 +212,11 @@ where
         r
     }
 
-    pub async fn read<const SIZE: usize, const ALIGN: usize>(
+    pub async fn read<const SIZE: usize>(
         &mut self,
         block_address: u32,
-        data: &mut [AlignedBuffer<SIZE, ALIGN>],
-    ) -> Result<(), Error>
-    where
-        Align<ALIGN>: Alignment,
-    {
+        data: &mut [Aligned<ALIGN, [u8; SIZE]>],
+    ) -> Result<(), Error> {
         self.cs.set_low().map_err(|_| Error::ChipSelect)?;
         let r = async {
             if data.len() == 1 {
@@ -239,14 +239,11 @@ where
         Ok(())
     }
 
-    pub async fn write<const SIZE: usize, const ALIGN: usize>(
+    pub async fn write<const SIZE: usize>(
         &mut self,
         block_address: u32,
-        data: &[AlignedBuffer<SIZE, ALIGN>],
-    ) -> Result<(), Error>
-    where
-        Align<ALIGN>: Alignment,
-    {
+        data: &[Aligned<ALIGN, [u8; SIZE]>],
+    ) -> Result<(), Error> {
         self.cs.set_low().map_err(|_| Error::ChipSelect)?;
         let r = async {
             if data.len() == 1 {
@@ -415,20 +412,21 @@ where
     }
 }
 
-impl<SPI, CS, D, const SIZE: usize, const ALIGN: usize>
-    block_device_driver::BlockDevice<SIZE, ALIGN> for SdSpi<SPI, CS, D>
+impl<SPI, CS, D, ALIGN, const SIZE: usize> block_device_driver::BlockDevice<SIZE>
+    for SdSpi<SPI, CS, D, ALIGN>
 where
     SPI: embedded_hal_async::spi::SpiBus,
     CS: embedded_hal::digital::OutputPin,
     D: embedded_hal_async::delay::DelayNs + Clone,
-    Align<ALIGN>: Alignment,
+    ALIGN: aligned::Alignment,
 {
     type Error = Error;
+    type Align = ALIGN;
 
     async fn read(
         &mut self,
         block_address: u32,
-        data: &mut [AlignedBuffer<SIZE, ALIGN>],
+        data: &mut [Aligned<ALIGN, [u8; SIZE]>],
     ) -> Result<(), Self::Error> {
         self.read(block_address, data).await
     }
@@ -436,7 +434,7 @@ where
     async fn write(
         &mut self,
         block_address: u32,
-        data: &[AlignedBuffer<SIZE, ALIGN>],
+        data: &[Aligned<ALIGN, [u8; SIZE]>],
     ) -> Result<(), Self::Error> {
         self.write(block_address, data).await
     }


### PR DESCRIPTION
We make alignment part of the base-level trait contract to avoid panicking paths in impls that require specific alignments.

## TODO
- [x] assert that ALIGN is a multiple of SIZE to avoid padding bytes