### PR TITLE
Move clock init to free func, update examples

### DIFF
--- a/examples/rp2040/Cargo.toml
+++ b/examples/rp2040/Cargo.toml
@@ -11,8 +11,6 @@ embassy-sync = { version = "0.5.0", features = ["defmt"] }
 embassy-executor = { version = "0.5.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
-embassy-usb = { version = "0.1.0", features = ["defmt"] }
-embassy-net = { version = "0.4.0", features = ["defmt", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-futures = { version = "0.1.0" }
 
 cortex-m = { version = "0.7.6", features = ["inline-asm"] }
@@ -39,3 +37,22 @@ embassy-time = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875
 embassy-rp = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
 embassy-futures = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
 embassy-embedded-hal = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
+
+# cargo build/run
+[profile.dev]
+codegen-units = 1
+debug = 2
+debug-assertions = true
+incremental = false
+opt-level = 3
+overflow-checks = true
+
+# cargo build/run --release
+[profile.release]
+codegen-units = 1
+debug = 2
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 3
+overflow-checks = false

--- a/sdspi/src/lib.rs
+++ b/sdspi/src/lib.rs
@@ -69,6 +69,17 @@ pub enum Error {
     WriteError,
 }
 
+/// Must be called between powerup and [SdSpi::init] to ensure the sdcard is properly initialized.
+pub async fn sd_init<SPI, BE>(spi: &mut SPI) -> Result<(), BE>
+where
+    SPI: embedded_hal_async::spi::SpiBus<Error = BE>,
+{
+    // Supply minimum of 74 clock cycles without CS asserted.
+    spi.write(&[0xFF; 10]).await?;
+
+    Ok(())
+}
+
 pub struct SdSpi<SPI, D, ALIGN>
 where
     SPI: embedded_hal_async::spi::SpiDevice,
@@ -96,14 +107,9 @@ where
         }
     }
 
+    /// To comply with the SD card spec, [sd_init] must be called between powerup and calling this function.
     pub async fn init(&mut self) -> Result<(), Error> {
         let r = async {
-            // Supply minimum of 74 clock cycles without CS asserted.
-            self.spi
-                .write(&[0xFF; 10])
-                .await
-                .map_err(|_| Error::SpiError)?;
-
             with_timeout(self.delay.clone(), 1000, async {
                 loop {
                     let r = self.cmd(idle()).await?;

--- a/sdspi/src/lib.rs
+++ b/sdspi/src/lib.rs
@@ -70,12 +70,14 @@ pub enum Error {
 }
 
 /// Must be called between powerup and [SdSpi::init] to ensure the sdcard is properly initialized.
-pub async fn sd_init<SPI, BE>(spi: &mut SPI) -> Result<(), BE>
+pub async fn sd_init<SPI, CS, BE>(spi: &mut SPI, cs: &mut CS) -> Result<(), Error>
 where
     SPI: embedded_hal_async::spi::SpiBus<Error = BE>,
+    CS: embedded_hal::digital::OutputPin,
 {
     // Supply minimum of 74 clock cycles without CS asserted.
-    spi.write(&[0xFF; 10]).await?;
+    cs.set_high().map_err(|_| Error::ChipSelect)?;
+    spi.write(&[0xFF; 10]).await.map_err(|_| Error::SpiError)?;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #29 

I feel like there should be a way to handle this that doesn't leave the footgun of forgetting the sd_init function, but I'm not sure how to do it.