### PR TITLE
Remove "Invalid FAT type" error message in try_fs_geometry()

### DIFF
--- a/embedded-fatfs/src/boot_sector.rs
+++ b/embedded-fatfs/src/boot_sector.rs
@@ -615,7 +615,6 @@ fn try_fs_geometry(
         total_sectors - u32::from(reserved_sectors) - root_dir_sectors - sectors_per_fat * u32::from(fats);
     let total_clusters = data_sectors / u32::from(sectors_per_cluster);
     if fat_type != FatType::from_clusters(total_clusters) {
-        error!("Invalid FAT type");
         return Err(Error::InvalidInput);
     }
     debug_assert!(total_clusters >= fat_type.min_clusters());


### PR DESCRIPTION
This function is called in a loop for each of the 3 FatType to find out which of the type can be used given some parameters, and it is designed to fail for some of the FatType, so it doesn't make much sense to print this error message.

Without this patch, formatting a small partition (which will select a Fat12 type) always print the "Invalid FAT type" error twice, even though it finishes successfully.