### PR TITLE
Stm32h7 dma error

### DIFF
--- a/block-device-adapters/src/buf_stream.rs
+++ b/block-device-adapters/src/buf_stream.rs
@@ -59,6 +59,17 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> BufStream<T, SIZE> {
         }
     }
 
+    /// Create a new [`BufStream`] around a hardware block device with external buffer.
+    pub fn new_with_buffer(inner: T, buf: [u8; SIZE]) -> Self {
+        Self {
+            inner,
+            current_block: u32::MAX,
+            current_offset: 0,
+            buffer: Aligned(buf),
+            dirty: false,
+        }
+    }
+
     /// Returns inner object.
     pub fn into_inner(self) -> T {
         self.inner

--- a/block-device-adapters/src/buf_stream.rs
+++ b/block-device-adapters/src/buf_stream.rs
@@ -38,29 +38,29 @@ impl<T: core::fmt::Debug> embedded_io_async::Error for BufStreamError<T> {
 ///
 /// [`BufStream<T, const SIZE: usize, const ALIGN: usize`](BufStream) implements the [`embedded_io_async`] traits, and implicitly
 /// handles the RMW (Read, Modify, Write) cycle for you.
-pub struct BufStream<T: BlockDevice<SIZE>, const SIZE: usize> {
+pub struct BufStream<'a, T: BlockDevice<SIZE>, const SIZE: usize> {
     inner: T,
-    buffer: Aligned<T::Align, [u8; SIZE]>,
+    buffer: Aligned<T::Align, &'a mut [u8]>,
     current_block: u32,
     current_offset: u64,
     dirty: bool,
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> BufStream<T, SIZE> {
+impl<'a, T: BlockDevice<SIZE>, const SIZE: usize> BufStream<'a, T, SIZE> {
     const ALIGN: usize = core::mem::align_of::<Aligned<T::Align, [u8; SIZE]>>();
     /// Create a new [`BufStream`] around a hardware block device.
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            current_block: u32::MAX,
-            current_offset: 0,
-            buffer: Aligned([0; SIZE]),
-            dirty: false,
-        }
-    }
+    // pub fn new(inner: T) -> Self {
+    //     Self {
+    //         inner,
+    //         current_block: u32::MAX,
+    //         current_offset: 0,
+    //         buffer: Aligned([0; SIZE]),
+    //         dirty: false,
+    //     }
+    // }
 
     /// Create a new [`BufStream`] around a hardware block device with external buffer.
-    pub fn new_with_buffer(inner: T, buf: [u8; SIZE]) -> Self {
+    pub fn new_with_buffer(inner: T, buf: &'a mut [u8]) -> Self {
         Self {
             inner,
             current_block: u32::MAX,
@@ -115,11 +115,11 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> BufStream<T, SIZE> {
     }
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> embedded_io_async::ErrorType for BufStream<T, SIZE> {
+impl<'a, T: BlockDevice<SIZE>, const SIZE: usize> embedded_io_async::ErrorType for BufStream<'a, T, SIZE> {
     type Error = BufStreamError<T::Error>;
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> Read for BufStream<T, SIZE> {
+impl<'a, T: BlockDevice<SIZE>, const SIZE: usize> Read for BufStream<'a, T, SIZE> {
     async fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, Self::Error> {
         let mut total = 0;
         let target = buf.len();
@@ -168,7 +168,7 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> Read for BufStream<T, SIZE> {
     }
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> Write for BufStream<T, SIZE> {
+impl<'a, T: BlockDevice<SIZE>, const SIZE: usize> Write for BufStream<'a, T, SIZE> {
     async fn write(&mut self, mut buf: &[u8]) -> Result<usize, Self::Error> {
         let mut total = 0;
         let target = buf.len();
@@ -234,7 +234,7 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> Write for BufStream<T, SIZE> {
     }
 }
 
-impl<T: BlockDevice<SIZE>, const SIZE: usize> Seek for BufStream<T, SIZE> {
+impl<'a, T: BlockDevice<SIZE>, const SIZE: usize> Seek for BufStream<'a, T, SIZE> {
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         self.current_offset = match pos {
             SeekFrom::Start(x) => x,


### PR DESCRIPTION
This pull request contains a proposal for using `SdSpi` with DMA on the STM32H7 series. I’m unsure if there are plans to support the STM32 series, and I don't think my code is the best implementation. However, I hope this draft pull request can serve as a hint for anyone who might want to pursue this in the future.

### Background

I am working on a project to run the Daisy Seed, a board designed for embedded audio, on Embassy. In this project, I was creating a simple recorder example. The recorder captures audio for about ten seconds after a button is pressed, stores it in RAM, and then automatically stops recording and writes the data to an SD card. While considering how to prevent SAI callbacks from overrunning while flushing to the SD card, I discovered `embedded-fatfs` and implemented an `async/await`-based flush procedure. However, the current `embedded-fatfs` cannot be used with the STM32H7. When I initially call `sdspi.init()`, I encounter an error like this:

```
ERROR panicked at 'DMA: error on DMA@40020000 channel 0'
```

This error is common with the STM32 series. For more details, please refer to:
[STM32 BDMA only working out of some RAM regions](https://embassy.dev/book/#_stm32_bdma_only_working_out_of_some_ram_regions)

To use DMA for SPI communication on the STM32, values must be written to a "specific" region before being communicated via DMA. My strategy is to let the `SdSpi` type own a pointer field that it always uses for every SPI communication, which might help avoid the above error. The code I wrote adds a slice field to the `SdSpi` type, intercepts all write() and transfer() operations, and copies values to the slice field. However, this results in increased complexity due to additional lifetime specifiers.

I initially intended to submit this pull request after successfully writing to the SD card. However, the SPI is not functioning and do timeouts, so I haven’t been able to confirm its operation. But anyway, it suppress panics by DMA. I’m unsure why time out is happening, but I’m probably making a mistake somewhere.

If you're interested in, Refer how this happened (and Please refer ‘oneshot_recorder’ for how I used new SdSpi):
https://github.com/Dicklessgreat/daisy_embassy/pull/10#issuecomment-2269646873

My environment: STM32H750 on Daisy Seed
https://electro-smith.com/products/daisy-seed