### PR TITLE
Update examples

### DIFF
--- a/examples/esp32c6/Cargo.toml
+++ b/examples/esp32c6/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-esp-hal = { version = "0.16.1", features = ["esp32c6", "eh1", "async", "embassy", "embassy-time-systick-16mhz", "embassy-executor-thread", "embassy-integrated-timers"] }
-esp-backtrace = { version = "0.11.0", features = ["esp32c6", "panic-handler", "exception-handler", "println"] }
-esp-println = { version = "0.9.0", features = ["esp32c6", "log"] }
+esp-hal = { version = "0.20.1", features = ["esp32c6", "async"] }
+esp-hal-embassy = { version = "0.3.0", features = ["esp32c6"] }
+esp-backtrace = { version = "0.14.1", features = ["esp32c6", "panic-handler", "exception-handler", "println"] }
+esp-println = { version = "0.11.0", features = ["esp32c6", "log"] }
 log = { version = "0.4.20" }
-embassy-time = "0.3"
-embassy-executor = { version = "0.5.0",  features = ["task-arena-size-8192"] }
+embassy-time = { version = "0.3", features = ["generic-queue-8"] }
+embassy-executor = { version = "0.6.0",  features = ["task-arena-size-8192"] }
 embedded-hal-async = "1"
 embedded-hal-bus = { version = "0.1.0", features = ["async", "defmt-03"] }
 static_cell = { version = "1", features = ["nightly"] }
@@ -19,12 +20,5 @@ embedded-io-async = "0.6"
 
 sdspi = { version = "0.1.0", path = "../../sdspi", features = ["log"] }
 aligned = "0.4.2"
-block-device-adapters = { version = "0.1.0", path = "../../block-device-adapters" }
+block-device-adapters = { version = "0.2.0", path = "../../block-device-adapters" }
 embedded-fatfs = { version = "0.1.0", path = "../../embedded-fatfs", default-features = false, features = ["log"] }
-
-
-[patch.crates-io]
-# We can remove this once https://github.com/embassy-rs/embassy/pull/2593 is released
-embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "4657c105473122017a2df0fec6449ffb401927f4" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy", rev = "4657c105473122017a2df0fec6449ffb401927f4" }
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "4657c105473122017a2df0fec6449ffb401927f4" }

--- a/examples/esp32c6/src/main.rs
+++ b/examples/esp32c6/src/main.rs
@@ -11,62 +11,58 @@ use embedded_io_async::{Read, Seek, Write};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
-    dma::Dma,
-    dma::DmaPriority,
-    dma_descriptors, embassy,
+    dma::*,
+    dma_buffers,
+    gpio::{Io, Level, Output},
     peripherals::Peripherals,
     prelude::*,
     spi::{
-        master::{prelude::*, Spi},
+        master::{Spi, SpiDmaBus},
         SpiMode,
     },
-    FlashSafeDma, IO,
+    system::SystemControl,
+    timer::timg::TimerGroup,
 };
 use sdspi::{self, SdSpi};
 
-#[main]
+#[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
     let peripherals = Peripherals::take();
-    let system = peripherals.SYSTEM.split();
-    let clocks = ClockControl::max(system.clock_control).freeze();
+    let system = SystemControl::new(peripherals.SYSTEM);
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    embassy::init(
-        &clocks,
-        esp_hal::systimer::SystemTimer::new(peripherals.SYSTIMER),
-    );
+    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    esp_hal_embassy::init(&clocks, timg0.timer0);
 
     esp_println::logger::init_logger_from_env();
     log::info!("Hello world!");
 
-    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio18;
     let miso = io.pins.gpio20;
     let mosi = io.pins.gpio19;
-    let cs = io.pins.gpio9;
+    let mut cs = Output::new(io.pins.gpio9, Level::High);
 
     let dma = Dma::new(peripherals.DMA);
     let dma_channel = dma.channel0;
 
-    let (mut descriptors, mut rx_descriptors) = dma_descriptors!(32000);
+    let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
+    let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+    let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
 
     // Initialize spi at the maxiumum SD initialization frequency of 400 khz
     let spi = Spi::new(peripherals.SPI2, 400u32.kHz(), SpiMode::Mode0, &clocks)
         .with_sck(sclk)
         .with_miso(miso)
         .with_mosi(mosi)
-        .with_dma(dma_channel.configure(
-            false,
-            &mut descriptors,
-            &mut rx_descriptors,
-            DmaPriority::Priority0,
-        ));
+        .with_dma(dma_channel.configure_for_async(false, DmaPriority::Priority0));
 
-    let mut spi = FlashSafeDma::<_, 512>::new(spi);
+    let mut spi = SpiDmaBus::new(spi, dma_tx_buf, dma_rx_buf);
 
     // Sd cards need to be clocked with a at least 74 cycles on their spi clock without the cs enabled,
     // sd_init is a helper function that does this for us.
     loop {
-        match sdspi::sd_init(&mut spi).await {
+        match sdspi::sd_init(&mut spi, &mut cs).await {
             Ok(_) => break,
             Err(e) => {
                 log::warn!("Sd init error: {:?}", e);
@@ -75,16 +71,15 @@ async fn main(_spawner: Spawner) {
         }
     }
 
-    let spid = ExclusiveDevice::new(spi, cs.into_push_pull_output(), embassy_time::Delay);
+    let spid = ExclusiveDevice::new(spi, cs, embassy_time::Delay);
     let mut sd = SdSpi::<_, _, aligned::A1>::new(spid, embassy_time::Delay);
 
     loop {
         // Initialize the card
-        if let Ok(_) = sd.init().await {
+        if sd.init().await.is_ok() {
             // Increase the speed up to the SD max of 25mhz
             sd.spi()
                 .bus_mut()
-                .inner_mut()
                 .change_bus_frequency(25u32.MHz(), &clocks);
             log::info!("Initialization complete!");
 

--- a/examples/rp2040/Cargo.toml
+++ b/examples/rp2040/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embassy-embedded-hal = { version = "0.1.0", features = ["defmt"] }
-embassy-sync = { version = "0.5.0", features = ["defmt"] }
-embassy-executor = { version = "0.5.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
-embassy-time = { version = "0.3.0", features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.1.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
+embassy-embedded-hal = { version = "0.2.0", features = ["defmt"] }
+embassy-sync = { version = "0.6.0", features = ["defmt"] }
+embassy-executor = { version = "0.6.0", features = ["task-arena-size-32768", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
+embassy-time = { version = "0.3.2", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-rp = { version = "0.2.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-futures = { version = "0.1.0" }
 
 cortex-m = { version = "0.7.6", features = ["inline-asm"] }
@@ -25,18 +25,8 @@ heapless = {version = "0.8", features = ["defmt-03"]}
 
 sdspi = { version = "0.1.0", path = "../../sdspi", features = ["defmt"] }
 aligned = "0.4.2"
-block-device-adapters = { version = "0.1.0", path = "../../block-device-adapters" }
+block-device-adapters = { version = "0.2.0", path = "../../block-device-adapters" }
 embedded-fatfs = { version = "0.1.0", path = "../../embedded-fatfs", default-features = false, features = ["defmt", "lfn"] }
-
-
-[patch.crates-io]
-# we can remove this once embassy #2732 is released: https://github.com/embassy-rs/embassy/pull/2732
-embassy-sync = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
-embassy-executor = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
-embassy-time = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
-embassy-rp = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
-embassy-futures = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
-embassy-embedded-hal = {git = "https://github.com/embassy-rs/embassy", rev = "a009275875228a3f9c59dcad114ef378b3f6f2ea" }
 
 # cargo build/run
 [profile.dev]

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
     let miso = p.PIN_16;
     let mosi = p.PIN_7;
     let clk = p.PIN_6;
-    let cs = Output::new(p.PIN_5, Level::High);
+    let mut cs = Output::new(p.PIN_5, Level::High);
 
     let mut config = Config::default();
     config.frequency = 400_000;
@@ -47,7 +47,7 @@ async fn main(_spawner: Spawner) {
     // Sd cards need to be clocked with a at least 74 cycles on their spi clock without the cs enabled,
     // sd_init is a helper function that does this for us.
     loop {
-        match sd_init(&mut spi).await {
+        match sd_init(&mut spi, &mut cs).await {
             Ok(_) => break,
             Err(e) => {
                 defmt::warn!("Sd init error: {}", e);
@@ -63,7 +63,7 @@ async fn main(_spawner: Spawner) {
 
     loop {
         // Initialize the card
-        if let Ok(_) = sd.init().await {
+        if sd.init().await.is_ok() {
             // Increase the speed up to the SD max of 25mhz
 
             let mut config = Config::default();


### PR DESCRIPTION
I forgot to update the examples for #30. This also removes the now-unnecessary patches for embassy-time. This was super easy for the rp example, but a fair amount has shifted around in esp-land, and I don't have an exp32c6 to test it with.