### PR TITLE
fix alloc feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,21 +60,30 @@ jobs:
           command: build
           args: -p embedded-fatfs --no-default-features --features lfn
 
+      - name: Run cargo build - no_std, alloc
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p embedded-fatfs --no-default-features --features alloc
+
       - name: Run cargo build - no_std, alloc, lfn, unicode
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: -p embedded-fatfs --no-default-features --features alloc,lfn,unicode
+
       - name: Run cargo build - no_std, alloc, lfn, unicode
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: -p embedded-fatfs --no-default-features --features alloc,lfn,unicode
+
       - name: Run cargo build - Check defmt
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: -p embedded-fatfs --no-default-features --features alloc,lfn,unicode,defmt
+
       - name: Run cargo build - Check log
         uses: actions-rs/cargo@v1
         with:

--- a/embedded-fatfs/src/dir.rs
+++ b/embedded-fatfs/src/dir.rs
@@ -1,4 +1,4 @@
-#[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use core::char;

--- a/embedded-fatfs/src/dir_entry.rs
+++ b/embedded-fatfs/src/dir_entry.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::iter;
 use core::str;
 
-#[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 #[cfg(feature = "lfn")]

--- a/embedded-fatfs/src/fs.rs
+++ b/embedded-fatfs/src/fs.rs
@@ -6,7 +6,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::u32;
 
-#[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 #[cfg(feature = "std")]
 use embedded_io_adapters::tokio_1::FromTokio;

--- a/embedded-fatfs/src/lib.rs
+++ b/embedded-fatfs/src/lib.rs
@@ -59,7 +59,7 @@
     clippy::uninlined_format_args, // not supported before Rust 1.58.0
 )]
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 // MUST be the first module listed


### PR DESCRIPTION
Hey, I've adjusted the feature flags so that `alloc` and `lfn` are independent, as it seems that the implementation does not require LFN to have dynamic memory allocation and visa-versa. 