### PR TITLE
chore: update to embedded-io-async 0.7

### DIFF
--- a/block-device-adapters/Cargo.toml
+++ b/block-device-adapters/Cargo.toml
@@ -13,7 +13,7 @@ Block device adapters for managing byte level access and partitions
 
 [dependencies]
 aligned = "0.4.2"
-embedded-io-async = "0.6.1"
+embedded-io-async = "0.7.0"
 block-device-driver = { version = "0.2", path = "../block-device-driver" }
 
 log = { version = "0.4", optional = true }
@@ -23,7 +23,7 @@ defmt = { version = "0.3", optional = true }
 env_logger = "0.9"
 tokio = { version = "1", default-features = false, features = ["fs", "rt-multi-thread", "macros", "io-util"] }
 anyhow = "1"
-embedded-io-adapters = { version = "0.6", package = "embedded-io-adapters", features = ["tokio-1"] }
+embedded-io-adapters = { version = "0.7", package = "embedded-io-adapters", features = ["tokio-1"] }
 
 [features]
 log = ["dep:log"]

--- a/block-device-adapters/src/buf_stream.rs
+++ b/block-device-adapters/src/buf_stream.rs
@@ -15,6 +15,16 @@ impl<T> From<T> for BufStreamError<T> {
     }
 }
 
+impl<T: core::fmt::Debug> core::fmt::Display for BufStreamError<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            BufStreamError::Io(e) => write!(f, "IO error: {:?}", e),
+        }
+    }
+}
+
+impl<T: core::fmt::Debug> core::error::Error for BufStreamError<T> {}
+
 impl<T: core::fmt::Debug> embedded_io_async::Error for BufStreamError<T> {
     fn kind(&self) -> ErrorKind {
         ErrorKind::Other
@@ -256,6 +266,10 @@ mod tests {
     impl<T: Read + Write + Seek> Write for TestBlockDevice<T> {
         async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
             Ok(self.0.write(buf).await?)
+        }
+
+        async fn flush(&mut self) -> Result<(), Self::Error> {
+            self.0.flush().await
         }
     }
 

--- a/block-device-adapters/src/stream_slice.rs
+++ b/block-device-adapters/src/stream_slice.rs
@@ -17,6 +17,16 @@ impl<E: Debug> From<E> for StreamSliceError<E> {
     }
 }
 
+impl<E: Debug> core::fmt::Display for StreamSliceError<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            StreamSliceError::InvalidSeek(pos) => write!(f, "Invalid seek position: {}", pos),
+            StreamSliceError::WriteZero => write!(f, "Write zero bytes"),
+            StreamSliceError::Other(e) => write!(f, "Other error: {:?}", e),
+        }
+    }
+}
+
 /// Stream wrapper for accessing limited segment of data from underlying file or device.
 pub struct StreamSlice<T: Read + Write + Seek> {
     inner: T,
@@ -24,6 +34,8 @@ pub struct StreamSlice<T: Read + Write + Seek> {
     current_offset: u64,
     size: u64,
 }
+
+impl<E: Debug> core::error::Error for StreamSliceError<E> {}
 
 impl<E: Debug> embedded_io_async::Error for StreamSliceError<E> {
     fn kind(&self) -> embedded_io_async::ErrorKind {

--- a/embedded-fatfs/Cargo.toml
+++ b/embedded-fatfs/Cargo.toml
@@ -37,10 +37,10 @@ default = ["chrono", "std", "alloc", "lfn", "unicode", "log"]
 [dependencies]
 # core deps
 bitflags = "1.0"
-embedded-io-async = "0.6.1"
+embedded-io-async = "0.7.0"
 
 # optional deps
-embedded-io-adapters = { version = "0.6", package = "embedded-io-adapters", features = ["tokio-1"], optional = true }
+embedded-io-adapters = { version = "0.7", package = "embedded-io-adapters", features = ["tokio-1"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 tokio = { version = "1", default-features = false, optional = true }
 elain = { version = "0.3", optional = true }

--- a/embedded-fatfs/src/boot_sector.rs
+++ b/embedded-fatfs/src/boot_sector.rs
@@ -972,6 +972,14 @@ mod tests {
             type Error = Self;
         }
 
+        impl core::fmt::Display for Dummy {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(f, "Dummy error")
+            }
+        }
+
+        impl core::error::Error for Dummy {}
+
         impl embedded_io_async::Error for Dummy {
             fn kind(&self) -> embedded_io_async::ErrorKind {
                 embedded_io_async::ErrorKind::TimedOut

--- a/embedded-fatfs/src/dir.rs
+++ b/embedded-fatfs/src/dir.rs
@@ -73,6 +73,7 @@ impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> Write for DirRawStream<'_, IO, TP
             DirRawStream::Root(raw) => raw.write(buf).await,
         }
     }
+
     async fn flush(&mut self) -> Result<(), Self::Error> {
         match self {
             DirRawStream::File(file) => file.flush().await,

--- a/embedded-fatfs/src/error.rs
+++ b/embedded-fatfs/src/error.rs
@@ -32,13 +32,13 @@ pub enum Error<T> {
     UnsupportedFileNameCharacter,
 }
 
-impl<T: Debug> IoError for Error<T> {
+impl<T: Debug + core::fmt::Display> IoError for Error<T> {
     fn kind(&self) -> ErrorKind {
         ErrorKind::Other
     }
 }
 
-impl<T: IoError> From<T> for Error<T> {
+impl<T: IoError + Debug + core::fmt::Display> From<T> for Error<T> {
     fn from(error: T) -> Self {
         Error::Io(error)
     }
@@ -53,7 +53,7 @@ impl<T> From<ReadExactError<Error<T>>> for Error<T> {
     }
 }
 
-impl<T: IoError> From<ReadExactError<T>> for Error<T> {
+impl<T: IoError + Debug + core::fmt::Display> From<ReadExactError<T>> for Error<T> {
     fn from(error: ReadExactError<T>) -> Self {
         match error {
             ReadExactError::UnexpectedEof => Self::UnexpectedEof,
@@ -80,13 +80,4 @@ impl<T: core::fmt::Display> core::fmt::Display for Error<T> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: std::error::Error + 'static> std::error::Error for Error<T> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        if let Error::Io(io_error) = self {
-            Some(io_error)
-        } else {
-            None
-        }
-    }
-}
+impl<T: Debug + core::fmt::Display> core::error::Error for Error<T> {}

--- a/embedded-fatfs/src/fs.rs
+++ b/embedded-fatfs/src/fs.rs
@@ -624,7 +624,7 @@ impl<IO: ReadWriteSeek, TP, OCC> FileSystem<IO, TP, OCC> {
     }
 
     /// Returns a root directory object allowing for futher penetration of a filesystem structure.
-    pub fn root_dir(&self) -> Dir<IO, TP, OCC> {
+    pub fn root_dir(&self) -> Dir<'_, IO, TP, OCC> {
         trace!("root_dir");
         let root_rdr = {
             match self.fat_type {


### PR DESCRIPTION
This PR updates embedded-io-async to latest version in order to be compatible with latest esp-generate and esp-hal.

Btw what are the plans with this project? Seems to be have the big benefit of being async over embedded-sdmmc, but is lacking some features like partitioning support and general stability tweaks.