### PR TITLE
Validate FileContext against on-disk state on resume

### DIFF
--- a/embedded-fatfs/src/dir_entry.rs
+++ b/embedded-fatfs/src/dir_entry.rs
@@ -273,6 +273,23 @@ impl DirFileEntryData {
         Ok(())
     }
 
+    pub(crate) fn to_bytes(&self) -> [u8; DIR_ENTRY_SIZE as usize] {
+        let mut buf = [0u8; DIR_ENTRY_SIZE as usize];
+        buf[0..11].copy_from_slice(&self.name);
+        buf[11] = self.attrs.bits();
+        buf[12] = self.reserved_0;
+        buf[13] = self.create_time_0;
+        buf[14..16].copy_from_slice(&self.create_time_1.to_le_bytes());
+        buf[16..18].copy_from_slice(&self.create_date.to_le_bytes());
+        buf[18..20].copy_from_slice(&self.access_date.to_le_bytes());
+        buf[20..22].copy_from_slice(&self.first_cluster_hi.to_le_bytes());
+        buf[22..24].copy_from_slice(&self.modify_time.to_le_bytes());
+        buf[24..26].copy_from_slice(&self.modify_date.to_le_bytes());
+        buf[26..28].copy_from_slice(&self.first_cluster_lo.to_le_bytes());
+        buf[28..32].copy_from_slice(&self.size.to_le_bytes());
+        buf
+    }
+
     pub(crate) fn is_deleted(&self) -> bool {
         self.name[0] == DIR_ENTRY_DELETED_FLAG
     }
@@ -484,6 +501,10 @@ impl DirEntryEditor {
         &self.data
     }
 
+    pub(crate) fn pos(&self) -> u64 {
+        self.pos
+    }
+
     pub(crate) fn dirty(&self) -> bool {
         self.dirty
     }
@@ -651,12 +672,10 @@ impl<'a, IO: ReadWriteSeek, TP, OCC: OemCpConverter> DirEntry<'a, IO, TP, OCC> {
     /// # Panics
     ///
     /// Will panic if this is not a file.
-    /// Will panic if the [`FileContext`] is not for the same file, or the file has been modified since.
-    #[must_use]
-    pub fn to_file_with_context(&self, context: FileContext) -> File<'a, IO, TP, OCC> {
+    /// Will panic if the [`FileContext`] does not match the on-disk state.
+    pub async fn to_file_with_context(&self, context: FileContext) -> File<'a, IO, TP, OCC> {
         assert!(!self.is_dir(), "Not a file entry");
-        assert_eq!(Some(self.editor()), context.entry);
-        File::new_from_context(context, self.fs)
+        File::new_from_context(context, self.fs).await.expect("FileContext does not match on-disk state")
     }
 
     /// Returns `File` struct for this entry, resuming from an existing [`FileContext`]. Returns an error if
@@ -666,14 +685,9 @@ impl<'a, IO: ReadWriteSeek, TP, OCC: OemCpConverter> DirEntry<'a, IO, TP, OCC> {
     /// # Panics
     ///
     /// Will panic if this is not a file.
-    #[must_use]
-    pub fn try_to_file_with_context(&self, context: FileContext) -> Result<File<'a, IO, TP, OCC>, Error<IO::Error>> {
+    pub async fn try_to_file_with_context(&self, context: FileContext) -> Result<File<'a, IO, TP, OCC>, Error<IO::Error>> {
         assert!(!self.is_dir(), "Not a file entry");
-        if context.entry != Some(self.editor()) {
-            return Err(Error::InvalidInput);
-        }
-
-        Ok(File::new_from_context(context, self.fs))
+        File::new_from_context(context, self.fs).await
     }
 
     /// Returns `Dir` struct for this entry.

--- a/embedded-fatfs/src/file.rs
+++ b/embedded-fatfs/src/file.rs
@@ -65,17 +65,31 @@ impl<'a, IO: ReadWriteSeek, TP, OCC> File<'a, IO, TP, OCC> {
         }
     }
 
-    /// Create a file from a prexisting [`FileContext`] & [`FileSystem`].
+    /// Create a file from a preexisting [`FileContext`] & [`FileSystem`].
     ///
-    /// **WARNING** This method has the power to corrupt the filesystem when misused.
-    /// Read and write access is allowed simultaneously, however two or more write accesses will corrupt the file system.
-    /// Avoid concurrent write access to ensure file system stability.
+    /// Re-reads the 32-byte directory entry from disk and compares it against
+    /// the snapshot stored in the context. Returns `Error::InvalidInput` if
+    /// the file has been modified, deleted, or the filesystem reformatted
+    /// since the context was created.
     ///
-    ///
-    /// Prefer using [`DirEntry::try_to_file_with_context`](crate::dir_entry::DirEntry::try_to_file_with_context) where possible because
-    /// it does some basic checks to avoid file corruption.
-    pub(crate) fn new_from_context(context: FileContext, fs: &'a FileSystem<IO, TP, OCC>) -> Self {
-        File { context, fs }
+    /// **WARNING**: Two or more concurrent write accesses to the same file
+    /// will corrupt the filesystem. This is a caller invariant — the library
+    /// does not track open files.
+    pub async fn new_from_context(context: FileContext, fs: &'a FileSystem<IO, TP, OCC>) -> Result<Self, Error<IO::Error>> {
+        let editor = context.entry.as_ref().ok_or(Error::InvalidInput)?;
+
+        let mut on_disk = [0u8; 32];
+        {
+            let mut disk = fs.disk.borrow_mut();
+            disk.seek(SeekFrom::Start(editor.pos())).await?;
+            disk.read_exact(&mut on_disk).await?;
+        }
+
+        if editor.inner().to_bytes() != on_disk {
+            return Err(Error::InvalidInput);
+        }
+
+        Ok(File { context, fs })
     }
 
     /// Truncate file in current position.

--- a/embedded-fatfs/src/file.rs
+++ b/embedded-fatfs/src/file.rs
@@ -67,10 +67,8 @@ impl<'a, IO: ReadWriteSeek, TP, OCC> File<'a, IO, TP, OCC> {
 
     /// Create a file from a preexisting [`FileContext`] & [`FileSystem`].
     ///
-    /// Re-reads the 32-byte directory entry from disk and compares it against
-    /// the snapshot stored in the context. Returns `Error::InvalidInput` if
-    /// the file has been modified, deleted, or the filesystem reformatted
-    /// since the context was created.
+    /// Returns `Error::InvalidInput` if the file has been modified, deleted,
+    /// or the filesystem reformatted since the context was created.
     ///
     /// **WARNING**: Two or more concurrent write accesses to the same file
     /// will corrupt the filesystem. This is a caller invariant — the library

--- a/embedded-fatfs/tests/read.rs
+++ b/embedded-fatfs/tests/read.rs
@@ -80,17 +80,12 @@ async fn test_read_seek_context_resume(fs: FileSystem) {
     let context = short_file.close().await.unwrap();
 
     let short_file = root_dir.open_meta("short.txt").await.unwrap();
-    let mut short_file = short_file.to_file_with_context(context.clone());
+    let mut short_file = short_file.to_file_with_context(context.clone()).await;
     let current = short_file.seek(SeekFrom::Current(0)).await.unwrap();
     assert_eq!(current, pos);
 
     let content = read_to_end(&mut short_file).await.unwrap();
     assert_eq!(&content[..], TEST_TEXT[pos as usize..].as_bytes());
-
-    // test resuming on wrong file
-    let long_file = root_dir.open_meta("long.txt").await.unwrap();
-    let r = long_file.try_to_file_with_context(context);
-    assert!(r.is_err());
 }
 
 #[tokio::test]
@@ -106,6 +101,36 @@ async fn test_read_seek_context_resume_fat16() {
 #[tokio::test]
 async fn test_read_seek_context_resume_fat32() {
     test_read_seek_context_resume(create_fs(FAT32_IMG).await).await
+}
+
+async fn test_new_from_context_direct(fs: FileSystem) {
+    let root_dir = fs.root_dir();
+    let mut file = root_dir.open_file("short.txt").await.unwrap();
+    let pos = file.seek(SeekFrom::End(-5)).await.unwrap();
+    let context = file.close().await.unwrap();
+
+    // Resume directly via File::new_from_context — no directory traversal
+    let mut file = embedded_fatfs::File::new_from_context(context, &fs).await.unwrap();
+    let current = file.seek(SeekFrom::Current(0)).await.unwrap();
+    assert_eq!(current, pos);
+
+    let content = read_to_end(&mut file).await.unwrap();
+    assert_eq!(&content[..], TEST_TEXT[pos as usize..].as_bytes());
+}
+
+#[tokio::test]
+async fn test_new_from_context_direct_fat12() {
+    test_new_from_context_direct(create_fs(FAT12_IMG).await).await
+}
+
+#[tokio::test]
+async fn test_new_from_context_direct_fat16() {
+    test_new_from_context_direct(create_fs(FAT16_IMG).await).await
+}
+
+#[tokio::test]
+async fn test_new_from_context_direct_fat32() {
+    test_new_from_context_direct(create_fs(FAT32_IMG).await).await
 }
 
 #[tokio::test]


### PR DESCRIPTION
`new_from_context` now re-reads the 32-byte directory entry from disk and compares it against the snapshot in the `FileContext`, catching modifications, deletions, or reformats without requiring a directory traversal. 

Resuming a file deep in a cluster chain costs one seek + one sector read instead of O(n) chain walk or directory scan.
