### PR TITLE
fix(embedded-fatfs): add explicit lifetime to root_dir return type

### DIFF
--- a/embedded-fatfs/src/fs.rs
+++ b/embedded-fatfs/src/fs.rs
@@ -624,7 +624,7 @@ impl<IO: ReadWriteSeek, TP, OCC> FileSystem<IO, TP, OCC> {
     }
 
     /// Returns a root directory object allowing for futher penetration of a filesystem structure.
-    pub fn root_dir(&self) -> Dir<IO, TP, OCC> {
+    pub fn root_dir(&self) -> Dir<'_, IO, TP, OCC> {
         trace!("root_dir");
         let root_rdr = {
             match self.fat_type {


### PR DESCRIPTION
## Summary
- Adds explicit `'_` lifetime to `root_dir()` return type to fix `mismatched_lifetime_syntaxes` warning on Rust 1.94+

## Test plan
- [x] `cargo build` passes without warning