### PR TITLE
fix: correct FAT spec compliance for status flags, sector count, and timestamps

### DIFF
--- a/embedded-fatfs/src/boot_sector.rs
+++ b/embedded-fatfs/src/boot_sector.rs
@@ -250,8 +250,8 @@ impl BiosParameterBlock {
             );
             return Err(Error::CorruptedFileSystem);
         }
-        if (self.total_sectors_16 == 0) == (self.total_sectors_32 == 0) {
-            error!("Invalid BPB (total_sectors_16 or total_sectors_32 should be non-zero)");
+        if self.total_sectors_16 == 0 && self.total_sectors_32 == 0 {
+            error!("Invalid BPB (total_sectors_16 and total_sectors_32 are both zero)");
             return Err(Error::CorruptedFileSystem);
         }
         let total_sectors = self.total_sectors();
@@ -333,7 +333,12 @@ impl BiosParameterBlock {
     }
 
     pub(crate) fn status_flags(&self) -> FsStatusFlags {
-        FsStatusFlags::decode(self.reserved_1)
+        if self.is_fat32() {
+            FsStatusFlags::decode(self.reserved_1)
+        } else {
+            // FAT12/FAT16 BPB does not carry status flags; they live in the FAT table
+            FsStatusFlags { dirty: false, io_error: false }
+        }
     }
 
     pub(crate) fn is_fat32(&self) -> bool {

--- a/embedded-fatfs/src/fs.rs
+++ b/embedded-fatfs/src/fs.rs
@@ -598,6 +598,10 @@ impl<IO: ReadWriteSeek, TP, OCC> FileSystem<IO, TP, OCC> {
     }
 
     pub(crate) async fn set_dirty_flag(&self, dirty: bool) -> Result<(), IO::Error> {
+        // FAT12/FAT16 BPB does not carry status flags; skip BPB write for non-FAT32
+        if self.fat_type() != FatType::Fat32 {
+            return Ok(());
+        }
         // Do not overwrite flags read from BPB on mount
         let mut flags = self.bpb.status_flags();
         flags.dirty |= dirty;
@@ -610,11 +614,7 @@ impl<IO: ReadWriteSeek, TP, OCC> FileSystem<IO, TP, OCC> {
         let encoded = flags.encode();
         // Note: only one field is written to avoid rewriting entire boot-sector which could be dangerous
         // Compute reserver_1 field offset and write new flags
-        let offset = if self.fat_type() == FatType::Fat32 {
-            0x041
-        } else {
-            0x025
-        };
+        let offset = 0x041u64;
         let mut disk = self.disk.borrow_mut();
         disk.seek(io::SeekFrom::Start(offset)).await?;
         disk.write_u8(encoded).await?;

--- a/embedded-fatfs/src/time.rs
+++ b/embedded-fatfs/src/time.rs
@@ -242,11 +242,14 @@ impl NullTimeProvider {
 
 impl TimeProvider for NullTimeProvider {
     fn get_current_date(&self) -> Date {
-        Date::decode(0)
+        Date { year: 1980, month: 1, day: 1 }
     }
 
     fn get_current_date_time(&self) -> DateTime {
-        DateTime::decode(0, 0, 0)
+        DateTime::new(
+            Date { year: 1980, month: 1, day: 1 },
+            Time { hour: 0, min: 0, sec: 0, millis: 0 },
+        )
     }
 }
 

--- a/embedded-fatfs/tests/write.rs
+++ b/embedded-fatfs/tests/write.rs
@@ -453,7 +453,7 @@ async fn test_rename_file_fat32() {
     call_with_fs(test_rename_file, FAT32_IMG, 6).await
 }
 
-async fn test_dirty_flag(tmp_path: String) {
+async fn test_dirty_flag_fat32_inner(tmp_path: String) {
     // Open filesystem, make change, and forget it - should become dirty
     let fs = open_filesystem_rw(tmp_path.clone()).await;
     let status_flags = fs.read_status_flags().await.unwrap();
@@ -474,19 +474,35 @@ async fn test_dirty_flag(tmp_path: String) {
     assert_eq!(status_flags.io_error(), false);
 }
 
+async fn test_dirty_flag_fat12_16_inner(tmp_path: String) {
+    // FAT12/FAT16 do not store dirty flags in the BPB, so the dirty flag
+    // is not persisted across mounts via BPB writes (only FAT32 does this).
+    let fs = open_filesystem_rw(tmp_path.clone()).await;
+    let status_flags = fs.read_status_flags().await.unwrap();
+    assert_eq!(status_flags.dirty(), false);
+    assert_eq!(status_flags.io_error(), false);
+    fs.root_dir().create_file("abc.txt").await.unwrap();
+    core::mem::forget(fs);
+    // FAT12/16: dirty flag is NOT persisted in BPB, so remount sees clean
+    let fs = open_filesystem_rw(tmp_path).await;
+    let status_flags = fs.read_status_flags().await.unwrap();
+    assert_eq!(status_flags.dirty(), false);
+    assert_eq!(status_flags.io_error(), false);
+}
+
 #[tokio::test]
 async fn test_dirty_flag_fat12() {
-    call_with_tmp_img(test_dirty_flag, FAT12_IMG, 7).await
+    call_with_tmp_img(test_dirty_flag_fat12_16_inner, FAT12_IMG, 7).await
 }
 
 #[tokio::test]
 async fn test_dirty_flag_fat16() {
-    call_with_tmp_img(test_dirty_flag, FAT16_IMG, 7).await
+    call_with_tmp_img(test_dirty_flag_fat12_16_inner, FAT16_IMG, 7).await
 }
 
 #[tokio::test]
 async fn test_dirty_flag_fat32() {
-    call_with_tmp_img(test_dirty_flag, FAT32_IMG, 7).await
+    call_with_tmp_img(test_dirty_flag_fat32_inner, FAT32_IMG, 7).await
 }
 
 async fn test_multiple_files_in_directory(fs: FileSystem) {


### PR DESCRIPTION
**Automated fix — please review before merging.**

- FAT12/FAT16: stop reading/writing status flags from BPB `reserved_1` (only valid on FAT32)
- Relax `total_sectors` validation to accept volumes with both fields set (only reject both-zero)
- `NullTimeProvider`: return valid 1980-01-01 instead of invalid month=0/day=0