### PR TITLE
Fixes for bugs in block-device-adapters 

### DIFF
--- a/block-device-adapters/src/buf_stream.rs
+++ b/block-device-adapters/src/buf_stream.rs
@@ -120,6 +120,12 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> embedded_io_async::ErrorType for B
 
 impl<T: BlockDevice<SIZE>, const SIZE: usize> Read for BufStream<T, SIZE> {
     async fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, Self::Error> {
+        // A zero-length read must be a no-op: forwarding it would otherwise
+        // satisfy the block-aligned fast path below and issue a 0-block device
+        // transfer (which some block devices, e.g. STM32 SDMMC DMA, reject).
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut total = 0;
         let target = buf.len();
         loop {
@@ -169,6 +175,12 @@ impl<T: BlockDevice<SIZE>, const SIZE: usize> Read for BufStream<T, SIZE> {
 
 impl<T: BlockDevice<SIZE>, const SIZE: usize> Write for BufStream<T, SIZE> {
     async fn write(&mut self, mut buf: &[u8]) -> Result<usize, Self::Error> {
+        // A zero-length write must be a no-op: forwarding it would otherwise
+        // satisfy the block-aligned fast path below and issue a 0-block device
+        // transfer (which some block devices, e.g. STM32 SDMMC DMA, reject).
+        if buf.is_empty() {
+            return Ok(0);
+        }
         let mut total = 0;
         let target = buf.len();
         loop {
@@ -550,5 +562,51 @@ mod tests {
             buf,
             ("A".repeat(524) + &"B".repeat(512) + &"C".repeat(512) + &"A".repeat(500)).into_bytes()
         )
+    }
+
+    /// A block device that panics if ever handed a 0-block transfer, used to
+    /// prove the `BufStream` empty-buffer guard never forwards one.
+    struct AssertNonEmptyBlockDevice;
+
+    impl BlockDevice<512> for AssertNonEmptyBlockDevice {
+        type Error = core::convert::Infallible;
+        type Align = A4;
+
+        async fn read(
+            &mut self,
+            _block_address: u32,
+            data: &mut [Aligned<A4, [u8; 512]>],
+        ) -> Result<(), Self::Error> {
+            assert!(!data.is_empty(), "0-block read forwarded to device");
+            Ok(())
+        }
+
+        async fn write(
+            &mut self,
+            _block_address: u32,
+            data: &[Aligned<A4, [u8; 512]>],
+        ) -> Result<(), Self::Error> {
+            assert!(!data.is_empty(), "0-block write forwarded to device");
+            Ok(())
+        }
+
+        async fn size(&mut self) -> Result<u64, Self::Error> {
+            Ok(u64::MAX)
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_transfers_are_noops() {
+        let mut block: BufStream<_, 512> = BufStream::new(AssertNonEmptyBlockDevice);
+        block.seek(SeekFrom::Start(0)).await.unwrap();
+
+        // Empty read/write must return Ok(0) without touching the device.
+        assert_eq!(block.write(&[]).await.unwrap(), 0);
+        assert_eq!(block.read(&mut []).await.unwrap(), 0);
+
+        // A real aligned transfer still reaches the device (sanity check that
+        // the assert above is actually armed).
+        let aligned: Aligned<A4, [u8; 512]> = Aligned([0xAB; 512]);
+        block.write_all(&aligned[..]).await.unwrap();
     }
 }

--- a/block-device-adapters/src/stream_slice.rs
+++ b/block-device-adapters/src/stream_slice.rs
@@ -82,6 +82,10 @@ impl<T: Read + Write + Seek> StreamSlice<T> {
 
 impl<T: Read + Write + Seek> Read for StreamSlice<T> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, StreamSliceError<T::Error>> {
+        if buf.is_empty() {
+            // A zero-length write is a no-op; forwarding it would be misreported as `WriteZero` or cause other issues
+            return Ok(0);
+        }
         // Narrow only after the min, so a remaining size exactly divisible by 4GiB isn't truncated to
         // 0 by `as usize` on 32-bit targets
         let remaining = self.size - self.current_offset;
@@ -94,6 +98,10 @@ impl<T: Read + Write + Seek> Read for StreamSlice<T> {
 
 impl<T: Read + Write + Seek> Write for StreamSlice<T> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, StreamSliceError<T::Error>> {
+        if buf.is_empty() {
+            // A zero-length write is a no-op; forwarding it would be misreported as `WriteZero` or cause other issues
+            return Ok(0);
+        }
         // Narrow only after the min, so a remaining size exactly divisible by 4GiB isn't truncated to
         // 0 by `as usize` on 32-bit targets
         let remaining = self.size - self.current_offset;
@@ -158,6 +166,24 @@ mod test {
         stream.seek(SeekFrom::Start(0)).await.unwrap();
         let data = read_to_string(&mut stream).await.unwrap();
         assert_eq!(data, "Test Rust");
+    }
+
+    #[tokio::test]
+    async fn empty_transfers_are_noops() {
+        let cur = std::io::Cursor::new("BeforeTest dataAfter".to_string().into_bytes());
+        let mut stream =
+            StreamSlice::new(embedded_io_adapters::tokio_1::FromTokio::new(cur), 6, 6 + 9)
+                .await
+                .unwrap();
+
+        // Empty write must be Ok(0), not `WriteZero`, and must not advance.
+        assert_eq!(stream.write(&[]).await.unwrap(), 0);
+        assert_eq!(stream.read(&mut []).await.unwrap(), 0);
+        assert_eq!(stream.seek(SeekFrom::Current(0)).await.unwrap(), 0);
+
+        // Data is still intact / readable afterwards.
+        let data = read_to_string(&mut stream).await.unwrap();
+        assert_eq!(data, "Test data");
     }
 
     /// A zero-storage `Read + Write + Seek` device with a virtual size, so a

--- a/block-device-adapters/src/stream_slice.rs
+++ b/block-device-adapters/src/stream_slice.rs
@@ -82,7 +82,10 @@ impl<T: Read + Write + Seek> StreamSlice<T> {
 
 impl<T: Read + Write + Seek> Read for StreamSlice<T> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, StreamSliceError<T::Error>> {
-        let max_read_size = cmp::min((self.size - self.current_offset) as usize, buf.len());
+        // Narrow only after the min, so a remaining size exactly divisible by 4GiB isn't truncated to
+        // 0 by `as usize` on 32-bit targets
+        let remaining = self.size - self.current_offset;
+        let max_read_size = cmp::min(remaining, buf.len() as u64) as usize;
         let bytes_read = self.inner.read(&mut buf[..max_read_size]).await?;
         self.current_offset += bytes_read as u64;
         Ok(bytes_read)
@@ -91,7 +94,10 @@ impl<T: Read + Write + Seek> Read for StreamSlice<T> {
 
 impl<T: Read + Write + Seek> Write for StreamSlice<T> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, StreamSliceError<T::Error>> {
-        let max_write_size = cmp::min((self.size - self.current_offset) as usize, buf.len());
+        // Narrow only after the min, so a remaining size exactly divisible by 4GiB isn't truncated to
+        // 0 by `as usize` on 32-bit targets
+        let remaining = self.size - self.current_offset;
+        let max_write_size = cmp::min(remaining, buf.len() as u64) as usize;
         let bytes_written = self.inner.write(&buf[..max_write_size]).await?;
         if bytes_written == 0 {
             return Err(StreamSliceError::WriteZero);
@@ -152,6 +158,67 @@ mod test {
         stream.seek(SeekFrom::Start(0)).await.unwrap();
         let data = read_to_string(&mut stream).await.unwrap();
         assert_eq!(data, "Test Rust");
+    }
+
+    /// A zero-storage `Read + Write + Seek` device with a virtual size, so a
+    /// multi-GiB `StreamSlice` can be tested without allocating anything.
+    struct Sink {
+        pos: u64,
+        len: u64,
+    }
+
+    impl embedded_io_async::ErrorType for Sink {
+        type Error = core::convert::Infallible;
+    }
+
+    impl Read for Sink {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            let n = cmp::min(self.len - self.pos, buf.len() as u64) as usize;
+            self.pos += n as u64;
+            Ok(n)
+        }
+    }
+
+    impl Write for Sink {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            let n = cmp::min(self.len - self.pos, buf.len() as u64) as usize;
+            self.pos += n as u64;
+            Ok(n)
+        }
+
+        async fn flush(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl Seek for Sink {
+        async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+            self.pos = match pos {
+                SeekFrom::Start(x) => x,
+                SeekFrom::Current(x) => (self.pos as i64 + x) as u64,
+                SeekFrom::End(x) => (self.len as i64 + x) as u64,
+            };
+            Ok(self.pos)
+        }
+    }
+
+    #[tokio::test]
+    async fn transfers_past_4gib_boundary_not_truncated() {
+        const G: u64 = 1024 * 1024 * 1024;
+        let mut slice = StreamSlice::new(Sink { pos: 0, len: 8 * G }, 0, 8 * G)
+            .await
+            .unwrap();
+
+        let data = [0xAAu8; 512];
+        assert_eq!(slice.write(&data).await.unwrap(), data.len());
+
+        slice.seek(SeekFrom::Start(4 * G)).await.unwrap(); // remaining == 2^32
+        let data = [0xAAu8; 512];
+        assert_eq!(slice.write(&data).await.unwrap(), data.len());
+
+        slice.seek(SeekFrom::Start(4 * G)).await.unwrap();
+        let mut rbuf = [0u8; 512];
+        assert_eq!(slice.read(&mut rbuf).await.unwrap(), rbuf.len());
     }
 
     async fn read_to_string<IO: embedded_io_async::Read>(io: &mut IO) -> Result<String, IO::Error> {


### PR DESCRIPTION
I've recently been prototyping replacing my use of another fat crate with this one, and in my testing hit a panic from embassy-stm32, as an SDMMC DMA write was issued a zero-length block. Initially, I thought this was deliberate or a side effect of a flush, and wrote the second commit (38bd3a3e5ea792570db9bf979ae509daf8ffbf6d) to force such cases to be a no-op. I then found that the zero-length write actually was due to a bug triggered by an oddity of my benchmarking code: I am writing files of exactly 1GiB in 32768 byte chunks to a fresh card, so at some point the remaining space at the start of a block write call is an exact multiple of 4GiB. Due to an order of operations bug, if `self.size - self.current_offset` is an exact multiple of 4GiB, we effectively do:

```rust
let len = min(u64_divisible_by_4GiB as u32 , buf.len()) /*i.e. 0 */;
 write(buf[..0]); /* i.e. write(&[]) */
```

(23784c317167273c3fc671f21bd76034e227f93a) fixes this by doing the min on `u64`s then truncating to `usize`.

I've added AI-derived unit tests of these fixes. I'm happy to remove/replace the somewhat verbose mock implementations, if there's a smarter way to handle that.

More details are in the commit messages and comments. I also wonder if there is a simple way to add a 32b system (even 32b linux) to CI, as this wasn't caught in CI because usize is already u64 and the bug did not cause truncation. 

Thanks for all your work on this crate!
