### PR TITLE
Zero-fill clusters allocated for the FAT32 root directory

### DIFF
--- a/embedded-fatfs/src/file.rs
+++ b/embedded-fatfs/src/file.rs
@@ -219,7 +219,11 @@ impl<'a, IO: ReadWriteSeek, TP, OCC> File<'a, IO, TP, OCC> {
     fn is_dir(&self) -> bool {
         match self.context.entry {
             Some(ref e) => e.inner().is_dir(),
-            None => false,
+            // The only stream without a directory entry is the FAT32 root directory: it must be
+            // treated as a directory so that clusters allocated when it grows are zero-filled.
+            // A non-zeroed directory cluster has no end-of-directory marker and its stale
+            // content gets parsed as bogus file or directory entries.
+            None => true,
         }
     }
 


### PR DESCRIPTION
File::is_dir returned false for streams without a directory entry, but the only such stream is the FAT32 root directory. When the root directory grew past its last cluster, the newly allocated cluster was therefore not zero-filled: it kept stale data from previously deleted files, which has no end-of-directory marker and gets parsed as directory entries.

Creating enough files (e.g. hundreds of entries with long file names) reliably produced bogus files and directories with garbled names and dates, even after a clean unmount.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/66e17533-c725-4df8-8c8c-bef8fdd35673" />

Treat entry-less streams as directories so alloc_cluster zeroes the new cluster.